### PR TITLE
Implement 'encoded' plotly-graph option

### DIFF
--- a/src/component/plotly-graph/parse.js
+++ b/src/component/plotly-graph/parse.js
@@ -8,10 +8,10 @@ const isNonEmptyString = require('../../util/is-non-empty-string')
  * @param {object} body : JSON-parsed request body
  *  - figure
  *  - format
- *  - encoded (?)
  *  - scale
  *  - width
  *  - height
+ *  - encoded
  *  - fid (figure id)
  * 0r:
  *  - data
@@ -46,9 +46,9 @@ function parse (body, _opts, sendToRenderer) {
     opts = _opts
   }
 
-  result.encoded = !!opts.encoded
   result.scale = isPositiveNumeric(opts.scale) ? Number(opts.scale) : cst.dflt.scale
   result.fid = isNonEmptyString(opts.fid) ? opts.fid : null
+  result.encoded = !!opts.encoded
 
   if (isNonEmptyString(opts.format)) {
     if (cst.contentFormat[opts.format]) {

--- a/src/component/plotly-graph/render.js
+++ b/src/component/plotly-graph/render.js
@@ -11,6 +11,7 @@ const cst = require('./constants')
  *  - width
  *  - height
  *  - scale
+ *  - encoded
  * @param {object} opts : component options
  *  - mapboxAccessToken
  * @param {function} sendToMain
@@ -21,6 +22,7 @@ const cst = require('./constants')
 function render (info, opts, sendToMain) {
   const figure = info.figure
   const format = info.format
+  const encoded = info.encoded
 
   const config = Object.assign({
     mapboxAccessToken: opts.mapboxAccessToken || '',
@@ -53,7 +55,7 @@ function render (info, opts, sendToMain) {
     // works as of https://github.com/plotly/plotly.js/compare/to-image-scale
     scale: info.scale,
     // return image data w/o the leading 'data:image' spec
-    imageDataOnly: !PRINT_TO_PDF,
+    imageDataOnly: !PRINT_TO_PDF && !encoded,
     // blend jpeg background color as jpeg does not support transparency
     setBackground: format === 'jpeg' ? 'opaque'
       : PRINT_TO_PDF ? pdfBackground
@@ -85,9 +87,17 @@ function render (info, opts, sendToMain) {
           case 'png':
           case 'jpeg':
           case 'webp':
-            return imgData.replace(cst.imgPrefix.base64, '')
+            if (encoded) {
+              return imgData
+            } else {
+              return imgData.replace(cst.imgPrefix.base64, '')
+            }
           case 'svg':
-            return decodeSVG(imgData)
+            if (encoded) {
+              return imgData
+            } else {
+              return decodeSVG(imgData)
+            }
           case 'pdf':
           case 'eps':
             return toPDF(imgData, imgOpts, bgColor)


### PR DESCRIPTION
resolves https://github.com/plotly/image-exporter/issues/7

- for plotly.js >= v1.30.0 encoded means setting `imageDataOnly` Plotly.toImage
  option to false in `render`
- for plotly.js < v1.30.0, bring `render` result to par w/ 1.30.0
- pdf and eps `encoded: true` output are handling in `convert`