### PR TITLE
Export image with dflt width/height when autosize is true

### DIFF
--- a/src/component/plotly-graph/parse.js
+++ b/src/component/plotly-graph/parse.js
@@ -90,15 +90,22 @@ function parse (body, _opts, sendToRenderer) {
     result.figure.layout = {}
   }
 
-  result.width = isPositiveNumeric(opts.width) ? Number(opts.width)
-    : isPositiveNumeric(result.figure.layout.width) ? Number(result.figure.layout.width)
-    : cst.dflt.width
-
-  result.height = isPositiveNumeric(opts.height) ? Number(opts.height)
-    : isPositiveNumeric(result.figure.layout.height) ? Number(result.figure.layout.height)
-    : cst.dflt.height
+  result.width = parseDim(result, opts, 'width')
+  result.height = parseDim(result, opts, 'height')
 
   sendToRenderer(null, result)
+}
+
+function parseDim (result, opts, dim) {
+  const layout = result.figure.layout
+
+  if (isPositiveNumeric(opts[dim])) {
+    return Number(opts[dim])
+  } else if (isPositiveNumeric(layout[dim]) && !layout.autosize) {
+    return Number(layout[dim])
+  } else {
+    return cst.dflt[dim]
+  }
 }
 
 module.exports = parse

--- a/test/unit/plotly-graph_test.js
+++ b/test/unit/plotly-graph_test.js
@@ -252,6 +252,19 @@ tap.test('parse:', t => {
         })
       })
 
+      shouldPass.forEach(d => {
+        t.test(`should fallback to dflt for ${d} with autosize turned on`, t => {
+          const body = {figure: {data: [], layout: { autosize: true }}}
+          body.figure.layout[k] = d
+
+          fn(body, {}, (errorCode, result) => {
+            t.equal(errorCode, null, 'code')
+            t.equal(result[k], dflt, 'result')
+            t.end()
+          })
+        })
+      })
+
       shouldFail.forEach(d => {
         t.test(`should fallback to layout ${k} for ${d}`, t => {
           const body = {figure: {data: [], layout: {}}}


### PR DESCRIPTION
as in old image server (see [logic](https://github.com/plotly/streambed/blob/e5e550648a7b60b32b63cb97f8cf18db5c76f4e1/image_server/server_app/middleware/get-plotsize.js#L20-L21)).

Is this _really_ the desired behavior though?