### PR TITLE
Thumbnail component

### DIFF
--- a/src/component/plotly-thumbnail/parse.js
+++ b/src/component/plotly-thumbnail/parse.js
@@ -1,4 +1,10 @@
 const plotlyGraphParse = require('../plotly-graph/parse')
+const isPlainObj = require('is-plain-obj')
+
+const counter = '([2-9]|[1-9][0-9]+)?$'
+const axNameRegex = new RegExp('^[xy]axis' + counter)
+const axIdRegex = new RegExp('^[xy]' + counter)
+const sceneRegex = new RegExp('^scene' + counter)
 
 /**
  * @param {object} body : JSON-parsed request body
@@ -16,12 +22,84 @@ function parse (body, opts, sendToRenderer) {
 }
 
 function overrideFigure (figure) {
+  const data = figure.data
   const layout = figure.layout
 
+  // remove title, margins and legend
   layout.title = ''
   layout.margin = {t: 0, b: 0, l: 0, r: 0}
+  layout.showlegend = false
 
-  // ... as in snapshot/cloneplot.js
+  // remove all annotations
+  delete layout.annotations
+
+  // remove color bars and pie labels
+  data.forEach(trace => {
+    trace.showscale = false
+    if (isPlainObj(trace.marker)) trace.marker.showscale = false
+    if (trace.type === 'pie') trace.textposition = 'none'
+  })
+
+  // remove title in base 2d axes
+  overrideAxis(layout, 'xaxis')
+  overrideAxis(layout, 'yaxis')
+
+  // remove title in base 3d axes
+  overrideScene(layout, 'scene')
+
+  // look for other axes in layout
+  for (var k in layout) {
+    if (axNameRegex.test(k)) {
+      overrideAxis(layout, k)
+    }
+    if (sceneRegex.test(k)) {
+      overrideScene(layout, k)
+    }
+  }
+
+  // look for traces linked to other 2d/3d axes
+  data.forEach(trace => {
+    if (axIdRegex.test(trace.xaxis)) {
+      overrideAxis(layout, id2name(trace.xaxis))
+    }
+    if (axIdRegex.test(trace.yaxis)) {
+      overrideAxis(layout, id2name(trace.yaxis))
+    }
+    if (sceneRegex.test(trace.scene)) {
+      overrideScene(layout, trace.scene)
+    }
+  })
+}
+
+function overrideAxis (container, axKey) {
+  if (!isPlainObj(container[axKey])) {
+    container[axKey] = {}
+  }
+
+  container[axKey].title = ''
+}
+
+function overrideScene (container, sceneKey) {
+  if (!isPlainObj(container[sceneKey])) {
+    container[sceneKey] = {}
+  }
+
+  var scene = container[sceneKey]
+  var axKeys = ['xaxis', 'yaxis', 'zaxis']
+
+  axKeys.forEach(k => {
+    if (!isPlainObj(scene[k])) {
+      scene[k] = {}
+    }
+
+    scene[k].title = ''
+    scene[k].showaxeslabels = false
+    scene[k].showticklabels = false
+  })
+}
+
+function id2name (id) {
+  return id.charAt(0) + 'axis' + id.substr(1)
 }
 
 module.exports = parse

--- a/test/unit/plotly-thumbnail_test.js
+++ b/test/unit/plotly-thumbnail_test.js
@@ -7,9 +7,45 @@ tap.test('parse:', t => {
   t.test('should fill in defaults', t => {
     const body = {
       figure: {
-        data: [{y: [1, 2, 1]}],
+        data: [{
+          y: [1, 2, 1],
+          xaxis: 'x2',
+          yaxis: 'y3'
+        }, {
+          scene: 'scene20'
+        }, {
+          type: 'pie',
+          marker: {}
+        }],
         layout: {
-          margin: {l: 100, r: 100, t: 100, b: 100}
+          margin: {l: 100, r: 100, t: 100, b: 100},
+          yaxis: {
+            title: 'some title',
+            otherAttr: 'dummy'
+          },
+          yaxis2: {
+            title: 'another title'
+          },
+          xaxis: {
+            color: 'blue',
+            title: 'yo'
+          },
+          xaxis14: {
+            title: 'yooo'
+          },
+          scene: {
+            xaxis: {
+              title: '3D !!!',
+              YO: 'yo'
+            }
+          },
+          scene3: {
+            zaxis: {
+              dummy: 'DUMMY',
+              showaxeslabels: true,
+              showticklabels: true
+            }
+          }
         }
       }
     }
@@ -18,10 +54,89 @@ tap.test('parse:', t => {
       t.equal(errorCode, null, 'code')
       t.same(result, {
         figure: {
-          data: [{y: [1, 2, 1]}],
+          data: [{
+            y: [1, 2, 1],
+            showscale: false,
+            xaxis: 'x2',
+            yaxis: 'y3'
+          }, {
+            scene: 'scene20',
+            showscale: false
+          }, {
+            type: 'pie',
+            showscale: false,
+            marker: {showscale: false},
+            textposition: 'none'
+          }],
           layout: {
             title: '',
-            margin: {b: 0, l: 0, r: 0, t: 0}
+            showlegend: false,
+            margin: {b: 0, l: 0, r: 0, t: 0},
+            yaxis: {
+              title: '',
+              otherAttr: 'dummy'
+            },
+            yaxis2: {title: ''},
+            yaxis3: {title: ''},
+            xaxis: {
+              color: 'blue',
+              title: ''
+            },
+            xaxis2: {title: ''},
+            xaxis14: {title: ''},
+            scene: {
+              xaxis: {
+                title: '',
+                showaxeslabels: false,
+                showticklabels: false,
+                YO: 'yo'
+              },
+              yaxis: {
+                title: '',
+                showaxeslabels: false,
+                showticklabels: false
+              },
+              zaxis: {
+                title: '',
+                showaxeslabels: false,
+                showticklabels: false
+              }
+            },
+            scene3: {
+              xaxis: {
+                title: '',
+                showaxeslabels: false,
+                showticklabels: false
+              },
+              yaxis: {
+                title: '',
+                showaxeslabels: false,
+                showticklabels: false
+              },
+              zaxis: {
+                dummy: 'DUMMY',
+                title: '',
+                showaxeslabels: false,
+                showticklabels: false
+              }
+            },
+            scene20: {
+              xaxis: {
+                title: '',
+                showaxeslabels: false,
+                showticklabels: false
+              },
+              yaxis: {
+                title: '',
+                showaxeslabels: false,
+                showticklabels: false
+              },
+              zaxis: {
+                title: '',
+                showaxeslabels: false,
+                showticklabels: false
+              }
+            }
           }
         },
         format: 'png',


### PR DESCRIPTION
resolves https://github.com/plotly/image-exporter/issues/20 with now on-par with [`snapshot`](https://github.com/plotly/plotly.js/blob/master/src/snapshot/cloneplot.js) in plotly.js. Note that I didn't port over themes-specific logic (as themes is obsolete).