### PR TITLE
Handle degenerate dashboard layout nodes 

### DIFF
--- a/src/component/plotly-dashboard-preview/parse.js
+++ b/src/component/plotly-dashboard-preview/parse.js
@@ -33,10 +33,10 @@ function parse (body, opts, sendToRenderer) {
       case 'split':
         return {
           type: 'split',
-          direction: cont.direction,
-          size: cont.size,
-          sizeUnit: cont.sizeUnit,
-          panels: [cont.first, cont.second].filter(d => d).map(parseFromType)
+          direction: cont.direction || 'horizontal',
+          size: cont.size || 50,
+          sizeUnit: cont.sizeUnit || '%',
+          panels: [cont.first, cont.second].filter(d => d).map(parseFromType).filter(d => d)
         }
       case 'box':
         return parseFromBoxType(cont)
@@ -49,8 +49,8 @@ function parse (body, opts, sendToRenderer) {
         return {
           type: 'box',
           contents: {
-            data: cont.figure.data || [],
-            layout: cont.figure.layout || {}
+            data: (cont.figure && cont.figure.data) || [],
+            layout: (cont.figure && cont.figure.layout) || {}
           }
         }
 
@@ -60,7 +60,7 @@ function parse (body, opts, sendToRenderer) {
           contents: {
             data: [],
             layout: {},
-            annotations: [{text: cont.text.substr(50)}]
+            annotations: [{text: cont.text ? cont.text.substr(50) : ''}]
           }
         }
 

--- a/src/component/plotly-dashboard-preview/render.js
+++ b/src/component/plotly-dashboard-preview/render.js
@@ -127,8 +127,8 @@ function render (info, opts, sendToMain) {
 
     const traversePanels = (p, path, width, height) => {
       const dir = p.direction
-      const size = p.size || 50
-      const sizeUnit = p.sizeUnit || '%'
+      const size = p.size
+      const sizeUnit = p.sizeUnit
       renderOneDiv(path, p.type === 'split' && dir === 'vertical')
       switch (p.type) {
         case 'box': {
@@ -155,7 +155,6 @@ function render (info, opts, sendToMain) {
           })
           break
         }
-        default: { }
       }
     }
 


### PR DESCRIPTION
It can happen that the dashboard layout has nodes with missing properties; eg. `type` is missing, or it's `split` but there's no direction etc. - some of these get defaults now (eg. `direction`: `horizontal`) while some will cause the node to be skipped.

The preexisting two defaulting (`size`, `sizeUnit`) were moved into `parse.js` for uniformity.

Thanks for @tarzzz for the report!