### PR TITLE
Switch from curl to wget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,8 @@ jobs:
           name: Smoke test Docker image
           command: |
             docker run -d -p 9091:9091/tcp --name imageserver gcr.io/${GOOGLE_PROJECT_ID}/imageserver:$CIRCLE_SHA1
-            docker run --network container:imageserver appropriate/curl --retry 60 --retry-connrefused --retry-delay 1 http://localhost:9091/ping
+            docker run --network container:imageserver quay.io/plotly/wget wget --retry-connrefused --waitretry=1 -t 60 -O /dev/null --progress=dot http://localhost:9091/ping
+
 
   docker-push:
     docker:


### PR DESCRIPTION
The latest version of `appropriate/curl` does not handle the `--retry-connrefused` argument correctly, and older versions are unavailable.  Switching to `wget` was the quickest fix, and I've uploaded the image we're using to our own repository on Quay so we don't run into this issue again even if `wget` changes.

@etpinard Please review

Fixes #36 