### PR TITLE
Add libgtk2.0-0 Aptitude dependency to the Docker Image

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:xenial
 # From: https://github.com/nodejs/docker-node/blob/master/6.11/Dockerfile
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        gnupg curl ca-certificates xz-utils wget libgconf-2-4 \
+        gnupg curl ca-certificates xz-utils wget libgtk2.0-0 libgconf-2-4 \
     && rm -rf /var/lib/apt/lists/* && apt-get clean
 
 RUN groupadd --gid 1000 node \


### PR DESCRIPTION
@etpinard @scjody 

From https://github.com/plotly/orca/pull/82#issuecomment-385512767:
> But can at least make a one-commit (off the current master) noise-less PR with just that one patch in the Dockerfile with a thorough explanation of why you did this to get our Docker expert @scjody to review the change? Thank you.

The `docker-build-and-push` CircleCI workflow step fails (specifically, the smoke test) when the Docker Image is built without access to a specific cached layer (often because it does not yet exist, speaking practically) (or choosing not to use the cache), _and_ `libgtk2.0-0` is not installed within the Image.

Kindly refer to the commits sequence and corresponding builds sequence linked just below, as they will tell the story best. Branching immediately off `master`, I first break the build simply by building without the Docker cache, then I fix the build simply by adding the new Aptitude dependency:

Github: Failure-and-fix demonstration branch: https://github.com/plotly/orca/compare/demonstrate-docker-image-build-failure?expand=1

CircleCI: Failure-and-fix demonstration branch: https://circleci.com/gh/plotly/orca/tree/demonstrate-docker-image-build-failure

_This_ pull request's branch, however, strictly contains the fix and not the experiment, for sake of clean revision history.

If you believe it to be wise, will you kindly accept this pull request?

―James