### PR TITLE
Clear cookies before loading dash app

### DIFF
--- a/src/component/plotly-dash-preview/render.js
+++ b/src/component/plotly-dash-preview/render.js
@@ -18,9 +18,13 @@ function render (info, opts, sendToMain) {
   createBrowserWindowOpts['show'] = opts.debug
 
   let win = remote.createBrowserWindow(createBrowserWindowOpts)
-  win.loadURL(info.url)
-
   const contents = win.webContents
+  const session = contents.session
+
+  // Clear cookies before loading URL
+  session.clearStorageData({}, () => {
+    win.loadURL(info.url)
+  })
 
   const done = errorCode => {
     win.close()

--- a/test/common.js
+++ b/test/common.js
@@ -28,6 +28,8 @@ function createMockWindow (opts = {}) {
 
   webContents.executeJavaScript = sinon.stub()
   webContents.printToPDF = sinon.stub()
+  webContents.session = sinon.stub()
+  webContents.session.clearStorageData = sinon.stub()
 
   Object.assign(win, opts, {
     webContents: webContents,

--- a/test/unit/plotly-dash-preview_test.js
+++ b/test/unit/plotly-dash-preview_test.js
@@ -99,6 +99,22 @@ tap.test('render:', t => {
     })
   })
 
+  t.test('should clear session cookies before loading dash-app', t => {
+    const win = createMockWindow()
+    sinon.stub(remote, 'createBrowserWindow').returns(win)
+    win.webContents.executeJavaScript.resolves(true)
+    win.webContents.printToPDF.yields(null, '-> image data <-')
+
+    fn({
+      url: 'https://dummy.com'
+    }, {}, (errorCode, result) => {
+      t.ok(win.webContents.session.clearStorageData.calledOnce)
+      t.equal(errorCode, undefined, 'code')
+      t.equal(result.imgData, '-> image data <-', 'result')
+      t.end()
+    })
+  })
+
   t.test('should handle executeJavascript errors', t => {
     const win = createMockWindow()
     sinon.stub(remote, 'createBrowserWindow').returns(win)


### PR DESCRIPTION
Fixes https://github.com/plotly/streambed/issues/10938

This ensures that any auth related cookies are not re-used for different users.

  - [x] Tested on On Prem
