### PR TITLE
Add 'table' safeMode specs

### DIFF
--- a/src/component/plotly-graph/parse.js
+++ b/src/component/plotly-graph/parse.js
@@ -148,23 +148,27 @@ function findMaxArrayLength (cont) {
     }
   })
 
-  let l = Math.max(0, ...lengths)
-
-  if (cont.type === 'table' && isPlainObj(cont.cells)) {
-    l = Math.max(l, findMaxArrayLength(cont.cells))
-  }
-  return l
+  return Math.max(0, ...lengths)
 }
 
 function estimateDataLength (trace) {
+  const topLevel = findMaxArrayLength(trace)
+  let dimLevel = 0
+  let cellLevel = 0
+
   // special case for e.g. parcoords and splom traces
   if (Array.isArray(trace.dimensions)) {
-    return trace.dimensions
+    dimLevel = trace.dimensions
       .map(findMaxArrayLength)
       .reduce((a, v) => a + v)
   }
 
-  return findMaxArrayLength(trace)
+  // special case for e.g. table traces
+  if (isPlainObj(trace.cells)) {
+    cellLevel = findMaxArrayLength(trace.cells)
+  }
+
+  return Math.max(topLevel, dimLevel, cellLevel)
 }
 
 function maxPtsPerTrace (trace) {

--- a/src/component/plotly-graph/parse.js
+++ b/src/component/plotly-graph/parse.js
@@ -148,7 +148,12 @@ function findMaxArrayLength (cont) {
     }
   })
 
-  return Math.max(0, ...lengths)
+  let l = Math.max(0, ...lengths)
+
+  if (cont.type === 'table' && isPlainObj(cont.cells)) {
+    l = Math.max(l, findMaxArrayLength(cont.cells))
+  }
+  return l
 }
 
 function estimateDataLength (trace) {
@@ -169,6 +174,7 @@ function maxPtsPerTrace (trace) {
     case 'scattergl':
     case 'splom':
     case 'pointcloud':
+    case 'table':
       return 1e7
 
     case 'scatterpolargl':

--- a/test/unit/plotly-graph_test.js
+++ b/test/unit/plotly-graph_test.js
@@ -395,6 +395,25 @@ tap.test('parse:', t => {
       })
     })
 
+    t.test('failing table case', t => {
+      fn({
+        data: [{
+          type: 'table',
+          cells: {
+            values: [
+              new Array(5e6),
+              new Array(5e6),
+              new Array(5e6)
+            ]
+          }
+        }]
+      }, {safeMode: true}, (errorCode, result) => {
+        t.equal(errorCode, 400, 'code')
+        t.type(result.msg, 'string', 'msg type')
+        t.end()
+      })
+    })
+
     t.test('failing case from too many traces', t => {
       var data = new Array(3e3)
 


### PR DESCRIPTION
I missed out on `table` traces in https://github.com/plotly/orca/pull/55, this PR adds them in.

cc @nicolaskruchten 