### PR TITLE
Hide electron icon from OS X dock

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     },
     "mac": {
       "category": "public.app-category.tools",
+      "extendInfo": {
+        "LSUIElement": 1
+      },
       "target": [
         "dmg"
       ]


### PR DESCRIPTION
resolves https://github.com/plotly/orca/issues/102

cc @jonmmease 