### PR TITLE
Server graph only

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -28,6 +28,11 @@ const OPTS_META = [].concat([{
   alias: ['windowMaxNumber', 'maxNumberOfWindows'],
   description: 'Sets maximum number of browser windows the server can keep open at a given time.'
 }, {
+  name: 'graph-only',
+  type: 'boolean',
+  alias: ['graphOnly'],
+  description: 'Launches only the graph component (not thumbnails, dash, etc.) to save memory and reduce the number of processes'
+}, {
   name: 'quiet',
   type: 'boolean',
   description: 'Suppress all logging info.'
@@ -72,15 +77,14 @@ function main (args) {
       console.log(`Spinning up server with pid: ${process.pid}`)
     }
 
-    app = orca.serve({
-      port: opts.port,
-      maxNumberOfWindows: opts.maxNumberOfWindows,
-      debug: opts.debug,
-      component: [{
-        name: 'plotly-graph',
-        route: '/',
-        options: plotlyJsOpts
-      }, {
+    let component = [{
+      name: 'plotly-graph',
+      route: '/',
+      options: plotlyJsOpts
+    }]
+
+    if (!opts.graphOnly) {
+      component.push({
         name: 'plotly-dashboard',
         route: '/dashboard'
       }, {
@@ -98,7 +102,14 @@ function main (args) {
       }, {
         name: 'plotly-dash-preview',
         route: '/dash-preview'
-      }]
+      })
+    }
+
+    app = orca.serve({
+      port: opts.port,
+      maxNumberOfWindows: opts.maxNumberOfWindows,
+      debug: opts.debug,
+      component: component
     })
 
     app.on('after-connect', (info) => {

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -31,7 +31,7 @@ const OPTS_META = [].concat([{
   name: 'graph-only',
   type: 'boolean',
   alias: ['graphOnly'],
-  description: 'Launches only the graph component (not thumbnails, dash, etc.) to save memory and reduce the number of processes'
+  description: 'Launches only the graph component (not thumbnails, dash, etc.) to save memory and reduce the number of processes.'
 }, {
   name: 'quiet',
   type: 'boolean',

--- a/test/integration/orca_serve_graph-only_test.js
+++ b/test/integration/orca_serve_graph-only_test.js
@@ -1,0 +1,82 @@
+const tap = require('tap')
+const Application = require('spectron').Application
+const request = require('request')
+
+const { paths } = require('../common')
+const PORT = 9109
+const SERVER_URL = `http://localhost:${PORT}`
+
+const app = new Application({
+  path: paths.bin,
+  args: ['serve', '--port', PORT, '--graph-only']
+})
+
+tap.tearDown(() => {
+  if (app && app.isRunning()) {
+    app.stop()
+  }
+})
+
+tap.test('should launch', t => {
+  app.start().then(() => {
+    app.client.getWindowCount().then(cnt => {
+      // Only one window since only graph component should be running
+      t.equal(cnt, 1)
+      t.end()
+    })
+  })
+})
+
+tap.test('should reply pong to ping POST', t => {
+  request.post(SERVER_URL + '/ping', (err, res, body) => {
+    if (err) t.fail(err)
+
+    t.equal(res.statusCode, 200, 'code')
+    t.equal(body, 'pong', 'body')
+    t.end()
+  })
+})
+
+tap.test('should work for *plotly-graph* component', t => {
+  request({
+    method: 'POST',
+    url: SERVER_URL + '/',
+    body: JSON.stringify({
+      figure: {
+        layout: {
+          data: [{y: [1, 2, 1]}]
+        }
+      }
+    })
+  }, (err, res, body) => {
+    if (err) t.fail(err)
+
+    t.equal(res.statusCode, 200, 'code')
+    t.type(body, 'string')
+    t.end()
+  })
+})
+
+tap.test('should teardown', t => {
+  app.stop()
+    .catch(t.fail)
+    .then(t.end)
+})
+
+tap.test('should not work for *plotly-thumbnail* component', t => {
+  request({
+    method: 'POST',
+    url: SERVER_URL + '/thumbnail',
+    body: JSON.stringify({
+      figure: {
+        layout: {
+          data: [{y: [1, 2, 1]}]
+        }
+      }
+    })
+  }, (err, res) => {
+    t.equal(err.code, 'ECONNREFUSED')
+    t.equal(res, undefined, 'should be undefined')
+    t.end()
+  })
+})


### PR DESCRIPTION
This PR supersedes #112 due to CI permissions issues. 

## Overview
Added a `--graph-only` boolean command line option to the `orca serve` entry point. When this option is present, only the `plotly-graph` component is run (not thumbnail, dash, etc.).

When graph conversion is the only service needed, this option reduces the number of electron processes, the memory usage, and startup time.

## Past Discussion
See https://github.com/plotly/orca/issues/110

## Resource usage comparison
Here's a comparison of the baseline resource usage on OSX

### Without `--graph-only` (legacy behavior)
![screen shot 2018-08-09 at 8 15 23 am](https://user-images.githubusercontent.com/15064365/43898908-52083636-9bae-11e8-8461-6f81b4f1ac6a.png)

There are 8 processes running, consuming ~390MB of memory.

Based on my testing from Python, from launching the server to receiving the first image conversion takes about 2.2 seconds.

### With `--graph-only
![screen shot 2018-08-09 at 8 15 59 am](https://user-images.githubusercontent.com/15064365/43898976-7fd3030c-9bae-11e8-893d-131c7ef26339.png)

There are 3 processes running, consuming ~120MB of memory.

Based on my testing from Python, from launching the server to receiving the first image conversion takes about 1.7 seconds.

### Resource Summary
If all you need is graph conversion, this flag saves 5 processes, 270MB of memory, and a half second of startup time.

## Testing
I added a new integration testing file at `test/integration/orca_serve_graph-only_test.js`.  This file is based on a subset of the testing in `test/integration/orca_serve_test.js`. But it checks to make sure there is only 1 window running, that the graph-component is running, and that the thumbnail component is not running.


