### PR TITLE
Skip `docker-build-and-push` on branches based off forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,14 @@ workflows:
           requires:
             - test-node-v6
             - test-node-v8
+          filters:
+              branches:
+                  # Do not run on branches based off forks as
+                  # this job requires plotly's quay.io credentials.
+                  # Note that branches based off forks are labels pull/???/ on CI.
+                  # Solution taken from:
+                  # https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419/4
+                  only: /^(?!pull\/).*$/
       - electron-pack-and-release:
           requires:
             - test-node-v6


### PR DESCRIPTION
... as this job requires plotly's quay.io credentials.

 Note that branches based off forks are labels pull/???/ on CI e.g:

![image](https://user-images.githubusercontent.com/6675409/43909842-49fd9a1a-9bc9-11e8-80f6-e6b43c2accd8.png)


Solution taken from: https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419/4
