### PR TITLE
Improvements to "Standalone binaries" installation processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,23 @@ your operating system from the
 
 #### Windows
 
-- Extract the `window-release.zip` file
-- In the `release` folder, double-click on `orca Setup X.Y.Z`, this will create an orca icon on your Desktop
-- Right-click on the orca icon, then click on _Properties_ and copy the _Starts in_ field
-- In the command prompt, run `PATH %PATH%;<paste the "Starts in" field here>`
+- Extract the `windows-release.zip` file.
+- In the `release` folder, double-click on `orca Setup X.Y.Z`, this will create an orca icon on your Desktop.
+- Right-click on the orca icon and select _Properties_ from the context menu.
+- From the _Shortcut_ tab, copy the directory in the _Start in_ field.
+- Add this _Start in_ directory to you system `PATH` (see below).
+- Open a new Command Prompt and verify that the orca executable is available on your `PATH`.
+
+```
+> orca --help
+Plotly's image-exporting utilities
+
+  Usage: orca [--version] [--help] <command> [<args>]
+  ...
+```
+
+##### Windows References
+ - How to set the path and environment variables in Windows: https://www.computerhope.com/issues/ch000549.htm
 
 #### Linux
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Plotly's image-exporting utilities
 $ chmod +x orca-X.Y.Z-x86_64.AppImage
 ```
 
-- Create a symbolic link named `orca` somewhere on your `$PATH` that points
+- Create a symbolic link named `orca` somewhere on your `PATH` that points
 to the AppImage.
 
 ```
@@ -112,11 +112,52 @@ Plotly's image-exporting utilities
   Usage: orca [--version] [--help] <command> [<args>]
   ...
 ```
+ 
+##### Linux Troubleshooting: Cannot open shared object
+The Electron runtime depends a several common system libraries. These
+libraries are pre-installed in most desktop Linux distributions
+(e.g. Ubuntu), but are not pre-installed on some server Linux distributions
+(e.g. Ubuntu Server). If a shared library is missing, you will see an error
+message like:
+
+```
+$ orca --help
+orca: error while loading shared libraries: libgtk-x11-2.0.so.0:
+cannot open shared object file: No such file or directory
+```
+
+On Ubuntu Server, these additional libraries can be installed with:
+
+```
+sudo apt-get install libgtk2.0-0 libxtst6 libxss1 libgconf-2-4 libnss3 libasound2
+```
+
+##### Linux Troubleshooting: Headless server configuration
+The Electron runtime requires the presence of an active X11 display server,
+but many server Linux distributions (e.g. Ubuntu Server) do not include X11
+by default.  If you do not wish to install X11 on your server, you may
+install and run orca with Xvfb instead.
+
+On Ubuntu Server, you can install Xvfb like this:
+```
+$ sudo apt-get install xvfb
+```
+
+To run orca under Xvfb, replace the symbolic link suggested above with a shell
+script that runs the orca AppImage executable using the `xvfb-run` command.
+
+```
+#!/bin/bash
+xvfb-run /path/to/orca-X.Y.Z-x86_64.AppImage "$@"
+```
+
+Name this shell script `orca` and place it somewhere or your system `PATH`.
 
 ##### Linux References
  - How to add directory to system path in Linux: https://www.computerhope.com/issues/ch001647.htm
  - AppImage: https://appimage.org/
-
+ - Xvfb: https://en.wikipedia.org/wiki/Xvfb
+ 
 ## Quick start
 
 From the command line:

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ orca: error while loading shared libraries: libgtk-x11-2.0.so.0:
 cannot open shared object file: No such file or directory
 ```
 
-On Ubuntu Server, these additional libraries can be installed with:
-
-```
-sudo apt-get install libgtk2.0-0 libxtst6 libxss1 libgconf-2-4 libnss3 libasound2
-```
+These additional dependencies can be satisfied by installing:
+ - The `libgtk2.0-0` and `libgconf-2-4` packages from your distribution's
+ software repository.
+ - The `google-chrome-stable` package from the [Google Linux Software
+ Repository](https://www.google.com/linuxrepositories/).
 
 ##### Linux Troubleshooting: Headless server configuration
 The Electron runtime requires the presence of an active X11 display server,

--- a/README.md
+++ b/README.md
@@ -60,8 +60,35 @@ your operating system from the
 
 #### Linux
 
-- Run `$ chmod +x orca-X.Y.Z-x86_64.AppImage`
-- Add it to your `$PATH`
+- Make the orca AppImage executable.
+
+```
+$ chmod +x orca-X.Y.Z-x86_64.AppImage
+```
+
+- Create a symbolic link named `orca` somewhere on your `$PATH` that points
+to the AppImage.
+
+```
+$ ln -s /path/to/orca-X.Y.Z-x86_64.AppImage /somewhere/on/PATH/orca
+```
+
+- Open a new terminal and verify that the orca executable is available on your `PATH`. 
+
+```
+$ which orca
+/somewhere/on/PATH/orca
+
+$ orca --help
+Plotly's image-exporting utilities
+
+  Usage: orca [--version] [--help] <command> [<args>]
+  ...
+```
+
+##### Linux References
+ - How to add directory to system path in Linux: https://www.computerhope.com/issues/ch001647.htm
+ - AppImage: https://appimage.org/
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,26 @@ your operating system from the
 
 #### Mac OS
 
-- Unzip `mac-release.zip` from your `Downloads/` folder
-- Double-click on `orca-X.Y.Z.dmg` file, that should open an installation window
-- Drag the orca icon into _Applications_
-- In finder, go to the `Applications/` folder
-- Right-click on the orca icon and click on _Open_, this should open an _Installation Succeeded_ window
-- Open the terminal and start using Orca!
+- Unzip the `mac-release.zip` file.
+- Double-click on the `orca-X.Y.Z.dmg` file. This will open an installation window.
+- Drag the orca icon into the `Applications` folder.
+- Open finder and navigate to the `Applications/` folder.
+- Right-click on the orca icon and select _Open_ from the context menu.
+- A password dialog will appear asking for permission to add orca to your system `PATH`.
+- Enter you password and click _OK_.
+- This should open an _Installation Succeeded_ window.
+- Open a new terminal and verify that the orca executable is available on your `PATH`. 
+
+```
+$ which orca
+/usr/local/bin/orca
+
+$ orca --help
+Plotly's image-exporting utilities
+
+  Usage: orca [--version] [--help] <command> [<args>]
+  ...
+```
 
 #### Windows
 

--- a/bin/orca_electron.js
+++ b/bin/orca_electron.js
@@ -44,44 +44,42 @@ if (process.platform === 'darwin' && process.argv.length === 1) {
       'To create your first image, open a terminal and run:\n\norca graph \'{ "data": [{"y": [1,2,1]}] }\' -o fig.png'
   }
 
-  let showMessage = false;
+  let showMessage = false
 
   try {
-      execSync('which orca');
-      // Orca is already on the path, nothing to do
-    } catch (err) {
+    execSync('which orca')
+    // Orca is already on the path, nothing to do
+  } catch (err) {
+    // Check if this is a standalone installation (not conda or npm)
+    const standalonePath = '/Applications/orca.app/Contents/MacOS/orca'
+    if (fs.existsSync(standalonePath)) {
+      // Now we know that orca is not on the path, but it is installed
+      // in the /Applications directory.  So we'll ask the user if they
+      // want to add it to the path
+      const source = path.join(__dirname, 'orca.sh')
+      const target = '/usr/local/bin/orca'
 
-      // Check if this is a standalone installation (not conda or npm)
-      const standalonePath = '/Applications/orca.app/Contents/MacOS/orca'
-      if (fs.existsSync(standalonePath)) {
+      if (!fs.existsSync(target)) {
+        // Build copy command
+        const copyCmd = `"cp ${source} ${target}"`
 
-        // Now we know that orca is not on the path, but it is installed
-        // in the /Applications directory.  So we'll ask the user if they
-        // want to add it to the path
-        const source = path.join(__dirname, 'orca.sh')
-        const target = '/usr/local/bin/orca'
+        // Use apple script to perform copy so that we can launch a GUI
+        // prompt for administrator credentials
+        const prompt = '"Add orca to system PATH (/usr/local/bin)?"'
+        const cmd = `osascript -e 'do shell script ${copyCmd} with prompt ${prompt} with administrator privileges'`
 
-        if (!fs.existsSync(target)) {
-          // Build copy command
-          const copyCmd = `"cp ${source} ${target}"`;
-
-          // Use apple script to perform copy so that we can launch a GUI
-          // prompt for administrator credentials
-          const prompt = '"Add orca to system PATH (/usr/local/bin)?"';
-          const cmd = `osascript -e 'do shell script ${copyCmd} with prompt ${prompt} with administrator privileges'`;
-
-          try {
-            execSync(cmd);
-            showMessage = true;
-          } catch (cmdErr) {
-            // User cancelled. Nothing more to do
-          }
+        try {
+          execSync(cmd)
+          showMessage = true
+        } catch (cmdErr) {
+          // User cancelled. Nothing more to do
         }
-      } else {
-        options.message = "Executable in non-standard location"
-        options.detail = "No orca executable located at /Applications/orca.app/\nNo changes made"
-        showMessage = true;
       }
+    } else {
+      options.message = 'Executable in non-standard location'
+      options.detail = 'No orca executable located at /Applications/orca.app/\nNo changes made'
+      showMessage = true
+    }
   }
 
   app.on('ready', function () {
@@ -91,7 +89,6 @@ if (process.platform === 'darwin' && process.argv.length === 1) {
     console.log(HELP)
     process.exit(options.type === 'error' ? 1 : 0)
   })
-
 } else if (opts._.length) {
   const cmd = opts._[0]
   const cmdArgs = args.slice(1)


### PR DESCRIPTION
## Overview
In preparation for the coming integration of orca into plotly.py, I reviewed and tested the "Standalone binaries" installation instructions for all three operating systems.  This PR contains the updates from this review.

In all cases, the goal is to make sure the user ends up with an executable named `orca` on the permanent system `PATH`.  This way the default plotly.py orca search logic will find it automatically.

I believe this is the last set of orca changes that we need before the plotly.py release. The Windows and Linux changes are documentation only.  The Mac OS changes include both documentation and installer updates.

I think this is the last set of changes in orca that we need before the plotly.py release.  I was picturing that we would release these changes as version 1.1.1 as soon as this PR is merged.

## Windows
The Windows installation instructions have been updated to direct the user to add the orca executable to their `PATH` permanently. The prior instructions only added it to the `PATH` for the current Command Prompt session. 

The actual environment variable instructions (for each Windows version) are delegated to a nice article on computerhope.com (https://www.computerhope.com/issues/ch001647.htm)

## Linux
The Linux installation instructions have been updated to direct the user to create a symbolic link named `orca` that points to the AppImage.  This way the user ends up with something name `orca` on their path (not `orca-X.Y.Z-x86_64.AppImage`).

Another computerhope.com reference was added to explain the concept of the `PATH` on Linux (https://www.computerhope.com/issues/ch001647.htm), along with a reference with some basic AppImage information (https://appimage.org/).

## Mac OS
The logic to add orca to the system `PATH` has been refined as follows:
 - Don't make any changes if `orca` is already on the `PATH`.
 - Only copy `orca.sh` to `/usr/local/bin` if orca is installed as an application (not if it's installed through conda or npm). I think this will address the trouble folks are running into in https://github.com/plotly/orca/issues/120.
 - Perform the `orca.sh` copy with administrator privileges to avoid permission denied errors (See https://github.com/plotly/orca/issues/111). This is done using Apple Script, which launches a nice GUI password prompt.

The README instructions are also updated to reflect the new installation process.

