### PR TITLE
add resources limit for proper scaling

### DIFF
--- a/deployment/kube/stage/frontend.yaml
+++ b/deployment/kube/stage/frontend.yaml
@@ -5,6 +5,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
   name: imageserver
   labels:
     app: imageserver
@@ -17,6 +19,15 @@ spec:
         tier: frontend
     spec:
       affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                    - imageserver
+              topologyKey: "failure-domain.beta.kubernetes.io/zone"
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -43,6 +54,13 @@ spec:
         ports:
         - name: http-server
           containerPort: 9091
+        resources:
+         limits:
+           cpu: 600m
+           memory: 1Gi
+         requests:
+           cpu: 400m
+           memory: 600Mi
         volumeMounts:
         - mountPath: "/usr/share/fonts/user"
           name: plotly-cloud-licensed-fonts

--- a/deployment/kube/stage/hpa.yaml
+++ b/deployment/kube/stage/hpa.yaml
@@ -14,5 +14,5 @@ spec:
   # Set this to 3x "min-nodes":
   minReplicas: 3
   # Set this to 3x "max-nodes":
-  maxReplicas: 3
+  maxReplicas: 6
   targetCPUUtilizationPercentage: 50

--- a/deployment/kube/stage/pdb.yaml
+++ b/deployment/kube/stage/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: imageserver-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: imageserver

--- a/deployment/run_server
+++ b/deployment/run_server
@@ -26,7 +26,7 @@ fi
 pkill Xvfb
 pkill node
 
-xvfb-run --auto-servernum --server-args '-screen 0 640x480x24' ./bin/orca.js serve --request-limit=1000 --safe-mode $PLOTLYJS_ARG $@ 1>/proc/1/fd/1 2>/proc/1/fd/2 &
+xvfb-run --auto-servernum --server-args '-screen 0 640x480x24' ./bin/orca.js serve --safe-mode $PLOTLYJS_ARG $@ 1>/dev/stdout 2>/dev/stderr &
 echo \$! > \$PIDFILE
 
 EOF


### PR DESCRIPTION
See plotly/streambed#9865 and plotly/streambed#11037

Reason for removing the --request-limit is because currently when we hit the 1000 requests the server exit but the container stays up monit handle the restart and when you do that the container is still healthy on the LB. So it is possible that client connect and hit a connection refused.

To avoid that I'm limiting the resources of the container cpu and memory in which if the app have a memory leak it will kill the container and making it unavailable to the LB and just spin a new container.

The annotation is required to scale-down, if a container spin-up on a node where kube-system is running so it tells it's okay to kill that node.

- [ ] issue with auto-balance doesn't work doesn't seem to down-scale node that should
- [ ] fined tuning the resources
- [ ] preemptive instances

tested with : 
ab -r -c 100 -n 100000 -p 86eac25f-4de9-4da2-82a9-0c7d28db1454_200.json http://10.128.0.17:9091/