### PR TITLE
adding readinessProbe

### DIFF
--- a/deployment/kube/prod/frontend.yaml
+++ b/deployment/kube/prod/frontend.yaml
@@ -87,6 +87,16 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /var/run/xvfb.pid
+          failureThreshold: 1
+          initialDelaySeconds: 20
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
       volumes:
       - name: plotly-cloud-licensed-fonts
         gcePersistentDisk:

--- a/deployment/kube/stage/frontend.yaml
+++ b/deployment/kube/stage/frontend.yaml
@@ -89,6 +89,16 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /var/run/xvfb.pid
+          failureThreshold: 1
+          initialDelaySeconds: 20
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
       volumes:
       - name: plotly-cloud-licensed-fonts
         gcePersistentDisk:


### PR DESCRIPTION
temporary removing from LB while monit restart the service. Avoid connection refused while scaling up/down or in case electron crash
