### PR TITLE
add support for CORS

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -40,6 +40,10 @@ const OPTS_META = [].concat([{
   name: 'debug',
   type: 'boolean',
   description: 'Starts app in debug mode.'
+}, {
+  name: 'cors',
+  type: 'boolean',
+  description: 'Enables Cross-Origin Resource Sharing (CORS)'
 }])
 
 const HELP_MSG = `orca serve
@@ -109,7 +113,8 @@ function main (args) {
       port: opts.port,
       maxNumberOfWindows: opts.maxNumberOfWindows,
       debug: opts.debug,
-      component: component
+      component: component,
+      cors: opts.cors
     })
 
     app.on('after-connect', (info) => {

--- a/src/app/server/coerce-opts.js
+++ b/src/app/server/coerce-opts.js
@@ -23,6 +23,7 @@ function coerceOpts (_opts = {}) {
     : cst.dflt.maxNumberOfWindows
 
   opts.debug = !!_opts.debug
+  opts.cors = !!_opts.cors
   opts._browserWindowOpts = { show: !!opts.debug }
 
   const _components = Array.isArray(_opts.component) ? _opts.component : [_opts.component]

--- a/src/app/server/create-server.js
+++ b/src/app/server/create-server.js
@@ -52,6 +52,17 @@ function createServer (app, BrowserWindow, ipcMain, opts) {
       return simpleReply(code, fullInfo.msg)
     }
 
+    // Set CORS headers
+    if (opts.cors) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Request-Method', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET', 'POST');
+      res.setHeader('Access-Control-Allow-Headers', '*');
+      if (req.method === 'OPTIONS') {
+        return simpleReply(200)
+      }
+    }
+
     req.once('error', () => simpleReply(401))
     req.once('close', () => simpleReply(499))
 

--- a/src/app/server/create-server.js
+++ b/src/app/server/create-server.js
@@ -54,10 +54,10 @@ function createServer (app, BrowserWindow, ipcMain, opts) {
 
     // Set CORS headers
     if (opts.cors) {
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      res.setHeader('Access-Control-Request-Method', '*');
-      res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET', 'POST');
-      res.setHeader('Access-Control-Allow-Headers', '*');
+      res.setHeader('Access-Control-Allow-Origin', '*')
+      res.setHeader('Access-Control-Request-Method', '*')
+      res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET', 'POST')
+      res.setHeader('Access-Control-Allow-Headers', '*')
       if (req.method === 'OPTIONS') {
         return simpleReply(200)
       }

--- a/src/app/server/create-server.js
+++ b/src/app/server/create-server.js
@@ -55,8 +55,7 @@ function createServer (app, BrowserWindow, ipcMain, opts) {
     // Set CORS headers
     if (opts.cors) {
       res.setHeader('Access-Control-Allow-Origin', '*')
-      res.setHeader('Access-Control-Request-Method', '*')
-      res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET', 'POST')
+      res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET, POST')
       res.setHeader('Access-Control-Allow-Headers', '*')
       if (req.method === 'OPTIONS') {
         return simpleReply(200)


### PR DESCRIPTION
Adds a `--cors` option to enable Cross-Origin Resource Sharing (CORS).

This may be out of scope for Orca since it can be handled at the HTTP layer by a downstream server but it was also very simple to add here.