### PR TITLE
K8s resources adjustment

### DIFF
--- a/deployment/kube/prod/frontend.yaml
+++ b/deployment/kube/prod/frontend.yaml
@@ -69,7 +69,7 @@ spec:
          limits:                                                                
            memory: 2396Mi                                                       
          requests:                                                              
-           cpu: 100m
+           cpu: 400m
            memory: 1Gi
         ports:
         - name: http-server

--- a/deployment/kube/prod/hpa.yaml
+++ b/deployment/kube/prod/hpa.yaml
@@ -15,4 +15,4 @@ spec:
   minReplicas: 3
   # Set this to 3x "max-nodes":
   maxReplicas: 18
-  targetCPUUtilizationPercentage: 30
+  targetCPUUtilizationPercentage: 150

--- a/deployment/kube/stage/frontend.yaml
+++ b/deployment/kube/stage/frontend.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: imageserver
 spec:
-  replicas: 3
+  replicas: 1
   strategy:
     rollingUpdate:
       maxSurge: 100%

--- a/deployment/kube/stage/frontend.yaml
+++ b/deployment/kube/stage/frontend.yaml
@@ -74,7 +74,7 @@ spec:
          limits:
            memory: 2396Mi
          requests:
-           cpu: 100m
+           cpu: 400m
            memory: 1Gi
         volumeMounts:
         - mountPath: "/usr/share/fonts/user"

--- a/deployment/kube/stage/hpa.yaml
+++ b/deployment/kube/stage/hpa.yaml
@@ -15,4 +15,4 @@ spec:
   minReplicas: 3
   # Set this to 3x "max-nodes":
   maxReplicas: 6
-  targetCPUUtilizationPercentage: 30
+  targetCPUUtilizationPercentage: 150

--- a/deployment/kube/stage/hpa.yaml
+++ b/deployment/kube/stage/hpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: imageserver
   # Set this to 3x "min-nodes":
-  minReplicas: 3
+  minReplicas: 1
   # Set this to 3x "max-nodes":
-  maxReplicas: 6
+  maxReplicas: 2
   targetCPUUtilizationPercentage: 150


### PR DESCRIPTION
part of plotly/streambed#11766

as per below I've miss-understood the CPU metric used by the auto-scale 
It is based of the cpu requests in our case it is very low at 100m and the percentage set is 90% so that mean at 90m we start scaling and by that it start spinning up new node. As per below:

```
kubectl describe hpa

  Normal  SuccessfulRescale  38m (x591 over 36d)   horizontal-pod-autoscaler  New size: 4; reason: cpu resource utilization (percentage of request) above target
  Normal  SuccessfulRescale  14m (x499 over 36d)   horizontal-pod-autoscaler  New size: 5; reason: cpu resource utilization (percentage of request) above target
  Normal  SuccessfulRescale  10m (x98 over 36d)    horizontal-pod-autoscaler  New size: 10; reason: cpu resource utilization (percentage of request) above target
  Normal  SuccessfulRescale  6m22s (x29 over 36d)  horizontal-pod-autoscaler  New size: 14; reason: cpu resource utilization (percentage of request) above target
  Normal  SuccessfulRescale  20s (x1548 over 36d)  horizontal-pod-autoscaler  New size: 3; reason: All metrics below target
```
so in our case we barely use 1400m so by increase the requests to 400m + a CPU target of 150% = 600m * 3  total of 1800m which give us more than what we need. Worst case the auto-scale will kick-in.
