### PR TITLE
Temporarily scale to 51 pods

### DIFF
--- a/deployment/kube/prod/hpa.yaml
+++ b/deployment/kube/prod/hpa.yaml
@@ -11,8 +11,8 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: imageserver
-  # Set this to 3x "min-nodes":
-  minReplicas: 3
-  # Set this to 3x "max-nodes":
-  maxReplicas: 18
+  # Normally this would be set to 3x "min-nodes":
+  minReplicas: 51
+  # Normally this would be set to 3x "max-nodes":
+  maxReplicas: 51
   targetCPUUtilizationPercentage: 30


### PR DESCRIPTION
Part of https://github.com/plotly/streambed/issues/11932

See https://github.com/plotly/streambed/issues/11932#issuecomment-442579644 for rationale. I went with 51 to allow a consistent number of nodes per zone.

I also plan on modifying the existing configuration for `default-pool` in the `prod` cluster (PlotlyCloud project):

![screen shot 2018-11-28 at 15 07 08](https://user-images.githubusercontent.com/1136329/49179058-70fd8a00-f31f-11e8-9cc7-e257c7496d72.png)
![screen shot 2018-11-28 at 15 07 35](https://user-images.githubusercontent.com/1136329/49179059-70fd8a00-f31f-11e8-92c1-a32859f88e09.png)

@mag009 Please review
@plotly/devops FYI