### PR TITLE
Revert "Temporarily scale to 51 pods"

### DIFF
--- a/deployment/kube/prod/hpa.yaml
+++ b/deployment/kube/prod/hpa.yaml
@@ -11,8 +11,8 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: imageserver
-  # Normally this would be set to 3x "min-nodes":
-  minReplicas: 51
-  # Normally this would be set to 3x "max-nodes":
-  maxReplicas: 51
+  # Set this to 3x "min-nodes":
+  minReplicas: 3
+  # Set this to 3x "max-nodes":
+  maxReplicas: 18
   targetCPUUtilizationPercentage: 30


### PR DESCRIPTION
Reverts plotly/orca#156

@nicolaskruchten and I discussed this on Friday. I'd like to revert this PR and set the node pool autoscaling parameters back the way they were (autoscaling on, max 6 nodes per zone) in the web UI.

Rationale:
* This change wasn't sufficient to prevent downtime (the user reached their throttle and then started hitting our backend sufficiently hard to crash it) and is expensive to keep in place.
* The user has agreed not to hit our site anymore.

@plotly/devops Any objections?
@mag009 Please review.