### PR TITLE
Install custom certificates

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -90,7 +90,7 @@ RUN apt-get update -y && apt-get install -y subversion && \
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' && \
     apt-get update -y && \
-    apt-get install -y google-chrome-stable xvfb poppler-utils git && \
+    apt-get install -y google-chrome-stable xvfb poppler-utils git libnss3-tools && \
     rm -rf /var/lib/apt/lists/* && apt-get clean
 
 COPY package.json /var/www/image-exporter/

--- a/deployment/run_server
+++ b/deployment/run_server
@@ -2,6 +2,15 @@
 
 fc-cache -v /usr/share/fonts/user
 
+# Install certificates present in data directory
+if [[ -d /data/ssl/ ]]; then
+  echo "Adding custom certificates..."
+  for CERT in `ls /data/ssl/*.crt`; do
+    echo "Adding:" $i
+    certutil -d sql:$HOME/.pki/nssdb -A -t "P,," -n $CERT -i $CERT
+  done
+fi
+
 BUILD_DIR=/var/www/image-exporter/build
 if [[ -n "${PLOTLY_JS_SRC}" ]]; then
   # Fetch plotly js bundle and save it locally:


### PR DESCRIPTION
Checks if there are custom certificates present under: `/data/ssl/`. Install them using `certutil` so that they can be verified by electron/chrome.

  - [ ] Test on on-prem.
