### PR TITLE
cache custom fonts

### DIFF
--- a/deployment/run_server
+++ b/deployment/run_server
@@ -2,6 +2,10 @@
 
 fc-cache -v /usr/share/fonts/user
 
+if [[ $PLOTLY_CUSTOM_FONTS_ENABLED = true ]]; then
+  fc-cache -v /usr/share/fonts/customer
+fi
+
 BUILD_DIR=/var/www/image-exporter/build
 if [[ -n "${PLOTLY_JS_SRC}" ]]; then
   # Fetch plotly js bundle and save it locally:


### PR DESCRIPTION
addresses remaining orca work for: https://github.com/plotly/streambed/issues/11328

 - [x] on-prem (tested all image formats ✔️ )

@scjody please review. 

**Note:**  Ultimately, all that was needed for Orca to be made aware of the new fonts was for the fonts to be added to the system font cache via `fc-cache`. 

**Important:** When testing, I discovered that the code being added is not strictly necessary because all fonts within `/usr/share/fonts` will be automatically added to the system font cache when the container starts up. I investigated this and I suspect what is happening is that the system font configuration file `/etc/fonts/fonts.conf` sets the font directories to be: 

```
<dir>/usr/share/fonts</dir>
<dir>/usr/local/share/fonts</dir>
```
and any application that uses the `fontconfig` library will update the font cache as needed (so `fc-cache` will be executed on `/usr/share/fonts` at that time). @etpinard any additional insight here? 

In any case, I think it's worth explicitly calling it ourselves as is done in the code change of this PR. 