### PR TITLE
Fix --output `orca graph` CLI option for path/to/filename

### DIFF
--- a/bin/graph.js
+++ b/bin/graph.js
@@ -101,8 +101,12 @@ function main (args) {
     process.exit(0)
   }
 
-  if (!fs.existsSync(opts.outputDir)) {
-    fs.mkdirSync(opts.outputDir)
+  const fullOutputDir = opts.output
+    ? path.join(opts.outputDir, path.dirname(opts.output))
+    : opts.outputDir
+
+  if (!fs.existsSync(fullOutputDir)) {
+    fs.mkdirSync(fullOutputDir)
   }
 
   getStdin().then((txt) => {
@@ -114,7 +118,7 @@ function main (args) {
 
     const write = (info, _, done) => {
       const itemName = getItemName(info)
-      const outPath = path.resolve(opts.outputDir, `${itemName}.${info.format}`)
+      const outPath = path.resolve(fullOutputDir, `${itemName}.${info.format}`)
 
       if (pipeToStdOut) {
         str(info.body)

--- a/test/integration/orca_graph_test.js
+++ b/test/integration/orca_graph_test.js
@@ -70,6 +70,18 @@ tap.test('should respect --output when set (just filename case)', t => {
   })
 })
 
+tap.test('should respect --output when set (path/to/filename case)', t => {
+  const subprocess = _spawn(t, [DUMMY_DATA, '--output=build/tmp/graph.png'])
+  const p = path.join(process.cwd(), 'build', 'tmp', 'graph.png')
+
+  subprocess.on('close', code => {
+    t.same(code, 0)
+    t.ok(fs.existsSync(p))
+    fs.unlinkSync(p)
+    t.end()
+  })
+})
+
 tap.test('should respect --output-dir when set', t => {
   const subprocess = _spawn(t, [DUMMY_DATA, '--output-dir=build'])
   const p = path.join(process.cwd(), 'build', 'fig.png')
@@ -85,6 +97,18 @@ tap.test('should respect --output-dir when set', t => {
 tap.test('should respect --output (filename) and --output-dir when set', t => {
   const subprocess = _spawn(t, [DUMMY_DATA, '--output-dir=build', '--output=graph.png'])
   const p = path.join(process.cwd(), 'build', 'graph.png')
+
+  subprocess.on('close', code => {
+    t.same(code, 0)
+    t.ok(fs.existsSync(p))
+    fs.unlinkSync(p)
+    t.end()
+  })
+})
+
+tap.test('should respect --output (path/to/filename) and --output-dir when set', t => {
+  const subprocess = _spawn(t, [DUMMY_DATA, '--output-dir=build', '--output=tmp/graph.png'])
+  const p = path.join(process.cwd(), 'build', 'tmp', 'graph.png')
 
   subprocess.on('close', code => {
     t.same(code, 0)


### PR DESCRIPTION
fixes #101 and adds a bunch more `orca --graph` tests

cc @antoinerg 