### PR TITLE
Bump deps and dev-deps 2018-12-28

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,18 +33,21 @@ npm install
 ### Install poppler
 
 We haven't found a Node.js library that converts PDF files to EPS,
-so we use [poppler](https://poppler.freedesktop.org/):
+so we use [poppler](https://poppler.freedesktop.org/). Orca also support EMF
+exports when [`inkscape`](https://inkscape.org/) is found in the environment. So
+to run the tests, you'll need to:
+
 
 On Debian-flavored Linux:
 
 ```
-apt-get poppler-utils
+apt-get poppler-utils inkscape
 ```
 
 On OS X:
 
 ```
-brew install poppler
+brew install poppler inkscape
 ```
 
 On Windows:

--- a/bin/orca.js
+++ b/bin/orca.js
@@ -8,4 +8,4 @@ const args = process.argv.slice(2)
 const pathToMain = path.join(__dirname, 'orca_electron.js')
 args.unshift(path.resolve(pathToMain))
 
-spawn(electronPath, args, {stdio: 'inherit'})
+spawn(electronPath, args, { stdio: 'inherit' })

--- a/bin/orca_electron.js
+++ b/bin/orca_electron.js
@@ -33,7 +33,7 @@ if (process.platform === 'darwin' && process.argv.length === 1) {
   const execSync = require('child_process').execSync
   const fs = require('fs')
   const path = require('path')
-  const {app, dialog} = require('electron')
+  const { app, dialog } = require('electron')
 
   const options = {
     type: 'info',

--- a/package-lock.json
+++ b/package-lock.json
@@ -6513,8 +6513,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.1.0",
@@ -6530,6 +6529,11 @@
       "requires": {
         "p-limit": "^1.1.0"
       }
+    },
+    "p-try": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
     "package-json": {
       "version": "4.0.1",
@@ -6890,18 +6894,18 @@
       }
     },
     "read-chunk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
-      "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.0.0.tgz",
+      "integrity": "sha512-8lBUVPjj9TC5bKLBacB+rpexM03+LWiYbv6ma3BeWmUYXGxqA1WNNgIZHq/iIsCrbFMzPhFbkOqdsyOFRnuoXg==",
       "requires": {
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1"
+        "pify": "^4.0.0",
+        "with-open-file": "^0.1.3"
       },
       "dependencies": {
         "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
       }
     },
@@ -8540,6 +8544,23 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        }
+      }
+    },
+    "with-open-file": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.4.tgz",
+      "integrity": "sha512-BswUwq/x/BYtNFMr4Uw9V+P2uroc9/tcDpZ2RdDHehzwCKJFF1PSIjJmBNfpUE3UQyJmVINRLOW49WTXQMEnvg==",
+      "requires": {
+        "p-finally": "^1.0.0",
+        "p-try": "^2.0.0",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,6 +1542,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true
+    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -2460,9 +2466,12 @@
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-isnumeric": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.1.tgz",
-      "integrity": "sha1-V7gcB6PAnLnsO++cFhgYmS2JNkM="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.2.tgz",
+      "integrity": "sha512-D7zJht1+NZBBv4759yXn/CJFUNJpILdgdosPFN1AjqQn9TfQJqSeCZfu0SY4bwIlXuDhzkxKoQ8BOqdiXpVzvA==",
+      "requires": {
+        "is-string-blank": "^1.0.1"
+      }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -2543,7 +2552,7 @@
     },
     "foreground-child": {
       "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "resolved": "http://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
@@ -2693,9 +2702,9 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3141,6 +3150,11 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-string-blank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -3611,9 +3625,9 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minipass": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
-      "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
@@ -3627,9 +3641,9 @@
           "dev": true
         },
         "yallist": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
@@ -6415,9 +6429,9 @@
       }
     },
     "opener": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.0.tgz",
-      "integrity": "sha512-MD4s/o61y2slS27zm2s4229V2gAUHX0/e3/XOmY/jsXwhysjjCIHN8lx7gqZCrZk19ym+HjCUWHeMKD7YJtKCQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
       "dev": true
     },
     "optimist": {
@@ -6460,7 +6474,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -7508,9 +7522,9 @@
       }
     },
     "stack-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
     },
     "standard": {
@@ -7773,51 +7787,76 @@
       }
     },
     "tap": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-12.0.1.tgz",
-      "integrity": "sha512-iEJytWaZy8risvfRjuV4+ST+Lrrui/MW2ZCWn01ZaMn0NKFej4+PpBy6bXGOg9+cEGNmI7d3Sdka/zTUZUGidA==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-12.1.1.tgz",
+      "integrity": "sha512-YPxCIzgrjCjdVt1F71snGLyebbAcbCs5uh74f5GPBkXFbcMgLjuDnopva+vgs9cqVv4mtSYBuxRS1/8C2ed7MQ==",
       "dev": true,
       "requires": {
         "bind-obj-methods": "^2.0.0",
-        "bluebird": "^3.5.1",
+        "bluebird": "^3.5.3",
+        "browser-process-hrtime": "^1.0.0",
+        "capture-stack-trace": "^1.0.0",
         "clean-yaml-object": "^0.1.0",
         "color-support": "^1.1.0",
-        "coveralls": "^3.0.1",
+        "coveralls": "^3.0.2",
+        "domain-browser": "^1.2.0",
         "foreground-child": "^1.3.3",
         "fs-exists-cached": "^1.0.0",
         "function-loop": "^1.0.1",
-        "glob": "^7.0.0",
+        "glob": "^7.1.3",
         "isexe": "^2.0.0",
-        "js-yaml": "^3.11.0",
-        "minipass": "^2.3.0",
+        "js-yaml": "^3.12.0",
+        "minipass": "^2.3.5",
         "mkdirp": "^0.5.1",
-        "nyc": "^11.8.0",
-        "opener": "^1.4.1",
+        "nyc": "^11.9.0",
+        "opener": "^1.5.1",
         "os-homedir": "^1.0.2",
         "own-or": "^1.0.0",
         "own-or-env": "^1.0.1",
         "rimraf": "^2.6.2",
         "signal-exit": "^3.0.0",
-        "source-map-support": "^0.5.6",
+        "source-map-support": "^0.5.9",
         "stack-utils": "^1.0.0",
         "tap-mocha-reporter": "^3.0.7",
         "tap-parser": "^7.0.0",
         "tmatch": "^4.0.0",
         "trivial-deferred": "^1.0.1",
-        "tsame": "^2.0.0",
+        "tsame": "^2.0.1",
         "write-file-atomic": "^2.3.0",
         "yapool": "^1.0.0"
       },
       "dependencies": {
+        "bluebird": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+          "dev": true
+        },
+        "browser-process-hrtime": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+          "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -7831,9 +7870,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.8",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.8.tgz",
-          "integrity": "sha512-WqAEWPdb78u25RfKzOF0swBpY0dKrNdjc4GvLwm7ScX/o9bj8Eh/YL8mcMhBHYDGl87UkkSXDOFnW4G7GhWhGg==",
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -7881,7 +7920,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -7897,7 +7936,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -8126,9 +8165,9 @@
       }
     },
     "tsame": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tsame/-/tsame-2.0.0.tgz",
-      "integrity": "sha512-dAuzcnOPdqZYojylFQzEes95UDjve3HqKrlTCeLZKSDPMTsn3smzHZqsJj/sWD8wOUkg0RD++B11evyLn2+bIw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tsame/-/tsame-2.0.1.tgz",
+      "integrity": "sha512-jxyxgKVKa4Bh5dPcO42TJL22lIvfd9LOVJwdovKOnJa4TLLrHxquK+DlGm4rkGmrcur+GRx+x4oW00O2pY/fFw==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,21 +99,10 @@
       }
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "^3.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
     },
     "acorn-walk": {
       "version": "6.1.1",
@@ -133,9 +122,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
     },
     "amdefine": {
@@ -374,27 +363,6 @@
         "define-properties": "^1.1.2",
         "es-abstract": "^1.7.0"
       }
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -1292,12 +1260,14 @@
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
@@ -1432,13 +1402,12 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "object-keys": "^1.0.12"
       },
       "dependencies": {
         "object-keys": {
@@ -1461,21 +1430,14 @@
         "pkg-config": "^1.1.0",
         "run-parallel": "^1.1.2",
         "uniq": "^1.0.1"
-      }
-    },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        }
       }
     },
     "delayed-stream": {
@@ -2027,14 +1989,14 @@
       }
     },
     "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
+        "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-promise": {
@@ -2075,60 +2037,61 @@
       }
     },
     "eslint": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
-      "integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
+      "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "babel-code-frame": "^6.22.0",
+        "ajv": "^6.5.0",
+        "babel-code-frame": "^6.26.0",
         "chalk": "^2.1.0",
-        "concat-stream": "^1.6.0",
-        "cross-spawn": "^5.1.0",
+        "cross-spawn": "^6.0.5",
         "debug": "^3.1.0",
         "doctrine": "^2.1.0",
-        "eslint-scope": "^3.7.1",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.2",
-        "esquery": "^1.0.0",
+        "espree": "^4.0.0",
+        "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^2.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob": "^7.1.2",
-        "globals": "^11.0.1",
-        "ignore": "^3.3.3",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.2",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^3.0.6",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.9.1",
+        "inquirer": "^5.2.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.11.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.2",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
         "path-is-inside": "^1.0.2",
         "pluralize": "^7.0.0",
         "progress": "^2.0.0",
+        "regexpp": "^2.0.0",
         "require-uncached": "^1.0.3",
-        "semver": "^5.3.0",
+        "semver": "^5.5.0",
         "strip-ansi": "^4.0.0",
-        "strip-json-comments": "~2.0.1",
-        "table": "4.0.2",
-        "text-table": "~0.2.0"
+        "strip-json-comments": "^2.0.1",
+        "table": "^4.0.3",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "version": "6.6.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+          "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
+            "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ansi-regex": {
@@ -2138,13 +2101,52 @@
           "dev": true
         },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         },
         "minimist": {
           "version": "0.0.8",
@@ -2161,6 +2163,28 @@
             "minimist": "0.0.8"
           }
         },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -2169,19 +2193,28 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
         }
       }
     },
     "eslint-config-standard": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
-      "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
+      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-5.0.0.tgz",
-      "integrity": "sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz",
+      "integrity": "sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -2204,22 +2237,32 @@
         "pkg-dir": "^1.0.0"
       }
     },
-    "eslint-plugin-import": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
-      "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+    "eslint-plugin-es": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
+      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.1.1",
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.1"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "dev": true,
+      "requires": {
         "contains-path": "^0.1.0",
         "debug": "^2.6.8",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.1.1",
+        "eslint-module-utils": "^2.2.0",
         "has": "^1.0.1",
         "lodash": "^4.17.4",
         "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0"
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
       },
       "dependencies": {
         "doctrine": {
@@ -2298,50 +2341,59 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
-      "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
+      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
       "dev": true,
       "requires": {
-        "ignore": "^3.3.6",
+        "eslint-plugin-es": "^1.3.1",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^4.0.2",
         "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
-        "semver": "^5.4.1"
+        "resolve": "^1.8.1",
+        "semver": "^5.5.0"
       }
     },
     "eslint-plugin-promise": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
-      "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
+      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
-      "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
+      "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
       "dev": true,
       "requires": {
-        "doctrine": "^2.0.2",
-        "has": "^1.0.1",
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
         "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2"
       }
     },
     "eslint-plugin-standard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-      "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
+      "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
       "dev": true
     },
     "eslint-scope": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -2350,13 +2402,22 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+          "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -2533,22 +2594,16 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
     },
     "foreground-child": {
       "version": "1.5.6",
@@ -2724,24 +2779,10 @@
       }
     },
     "globals": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
       "dev": true
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
     },
     "globule": {
       "version": "1.2.1",
@@ -2836,6 +2877,12 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "highlight.js": {
       "version": "9.12.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
@@ -2894,9 +2941,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
     "image-size": {
@@ -3083,21 +3130,6 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -3157,10 +3189,13 @@
       "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -6814,9 +6849,9 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "progress-stream": {
@@ -6983,6 +7018,12 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
     "registry-auth-token": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
@@ -7092,12 +7133,12 @@
       }
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -7174,6 +7215,15 @@
       "dev": true,
       "requires": {
         "rx-lite": "*"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
@@ -7307,15 +7357,15 @@
       }
     },
     "snazzy": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/snazzy/-/snazzy-7.1.1.tgz",
-      "integrity": "sha512-gJ46s+jcwOeRhO9uEkTyzcREFZ0c5LZOgcVakLxTPIvhRIywKvbvArvMg5e8bBbpWe4InC/8eyEQOGXgJVNOfw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/snazzy/-/snazzy-8.0.0.tgz",
+      "integrity": "sha512-59GS69hQD8FvJoNGeDz8aZtbYhkCFxCPQB1BFzAWiVVwPmS/J6Vjaku0k6tGNsdSxQ0kAlButdkn8bPR2hLcBw==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
         "inherits": "^2.0.1",
         "minimist": "^1.1.1",
-        "readable-stream": "^2.0.6",
+        "readable-stream": "^3.0.2",
         "standard-json": "^1.0.0",
         "strip-ansi": "^4.0.0",
         "text-table": "^0.2.0"
@@ -7327,63 +7377,21 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-          "dev": true
-        },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -7396,15 +7404,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -7532,26 +7531,26 @@
       "dev": true
     },
     "standard": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-11.0.1.tgz",
-      "integrity": "sha512-nu0jAcHiSc8H+gJCXeiziMVZNDYi8MuqrYJKxTgjP4xKXZMKm311boqQIzDrYI/ktosltxt2CbDjYQs9ANC8IA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-12.0.1.tgz",
+      "integrity": "sha512-UqdHjh87OG2gUrNCSM4QRLF5n9h3TFPwrCNyVlkqu31Hej0L/rc8hzKqVvkb2W3x0WMq7PzZdkLfEcBhVOR6lg==",
       "dev": true,
       "requires": {
-        "eslint": "~4.18.0",
-        "eslint-config-standard": "11.0.0",
-        "eslint-config-standard-jsx": "5.0.0",
-        "eslint-plugin-import": "~2.9.0",
-        "eslint-plugin-node": "~6.0.0",
-        "eslint-plugin-promise": "~3.7.0",
-        "eslint-plugin-react": "~7.7.0",
-        "eslint-plugin-standard": "~3.0.1",
-        "standard-engine": "~8.0.0"
+        "eslint": "~5.4.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-config-standard-jsx": "6.0.2",
+        "eslint-plugin-import": "~2.14.0",
+        "eslint-plugin-node": "~7.0.1",
+        "eslint-plugin-promise": "~4.0.0",
+        "eslint-plugin-react": "~7.11.1",
+        "eslint-plugin-standard": "~4.0.0",
+        "standard-engine": "~9.0.0"
       }
     },
     "standard-engine": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-8.0.1.tgz",
-      "integrity": "sha512-LA531C3+nljom/XRvdW/hGPXwmilRkaRkENhO3FAGF1Vtq/WtCXzgmnc5S6vUHHsgv534MRy02C1ikMwZXC+tw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-9.0.0.tgz",
+      "integrity": "sha512-ZfNfCWZ2Xq67VNvKMPiVMKHnMdvxYzvZkf1AH8/cw2NLDBm5LRsxMqvEJpsjLI/dUosZ3Z1d6JlHDp5rAvvk2w==",
       "dev": true,
       "requires": {
         "deglob": "^2.1.0",
@@ -7569,9 +7568,9 @@
       }
     },
     "standard-json": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/standard-json/-/standard-json-1.0.2.tgz",
-      "integrity": "sha1-gt6koUx4zZ4104zeS4isa2JZaiM=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/standard-json/-/standard-json-1.0.3.tgz",
+      "integrity": "sha512-lhMP+KREBcfyyMe2ObJlEjJ0lc0ItA9uny83d9ZL6ggYtB79DuaAKCxJVoiflg5EV3D2rpuWn+n4+zXjWXk0sQ==",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0"
@@ -7726,37 +7725,31 @@
         }
       }
     },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
+    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
     },
     "table": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "version": "4.0.3",
+      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "^5.2.3",
-        "ajv-keywords": "^2.1.0",
+        "ajv": "^6.0.1",
+        "ajv-keywords": "^3.0.0",
         "chalk": "^2.1.0",
         "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2512,9 +2512,9 @@
       }
     },
     "file-type": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
-      "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.7.0.tgz",
+      "integrity": "sha512-AbaGtdWYYRaVrv2MwL/65myuRJ9j3e79e7etJ79US18QHuVlzJBcQHUH+HxDUoLtbyWRTUfLzLkGXX3pP9kfZg=="
     },
     "find-root": {
       "version": "1.1.0",
@@ -2552,7 +2552,7 @@
     },
     "foreground-child": {
       "version": "1.5.6",
-      "resolved": "http://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
@@ -6474,7 +6474,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -7850,13 +7850,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -7920,7 +7920,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -7936,7 +7936,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,7 +350,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-find-index": {
@@ -1015,6 +1015,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.4.tgz",
+      "integrity": "sha512-6Y+iBnWmXL+AWtlOp2Vr6R2w5MUlNJRwR0ShVFaAb1CqWzhPOpQg4L0jxD+xpw/Nc8QJwaq3KM79QUCriY8CWQ==",
       "dev": true
     },
     "combined-stream": {
@@ -2128,7 +2134,7 @@
         },
         "inquirer": {
           "version": "5.2.0",
-          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
           "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "dev": true,
           "requires": {
@@ -3597,6 +3603,15 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
       }
     },
     "map-obj": {
@@ -6564,10 +6579,22 @@
         "own-or": "^1.0.0"
       }
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "dev": true
     },
     "p-limit": {
       "version": "1.1.0",
@@ -6904,6 +6931,16 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
       "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -7075,6 +7112,190 @@
       "dev": true,
       "requires": {
         "is-finite": "^1.0.0"
+      }
+    },
+    "replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace/-/replace-1.0.1.tgz",
+      "integrity": "sha512-Qh0XcLMb3LYa6fs7V30zQHACbJTQJUERl22lVjaq0dJp6B5q1t/vARXDauS1ywpIs3ZkT3APj4EA6aOoHoaHDA==",
+      "dev": true,
+      "requires": {
+        "colors": "1.2.4",
+        "minimatch": "3.0.4",
+        "yargs": "12.0.5"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+          "dev": true
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+          "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^1.1.0"
+          }
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "dev": true,
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "request": {
@@ -7749,7 +7970,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -8052,7 +8273,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7212,9 +7212,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "semver-diff": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1267,22 +1267,24 @@
       }
     },
     "cross-env": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.4.tgz",
-      "integrity": "sha512-Mx8mw6JWhfpYoEk7PGvHxJMLQwQHORAs8+2bX+C1lGQ4h3GkDb1zbzC2Nw85YH9ZQMlO0BHZxMacgrfPmMFxbg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.1.0",
+        "cross-spawn": "^6.0.5",
         "is-windows": "^1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
           }
@@ -3665,6 +3667,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "nise": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,28 +37,33 @@
       "optional": true
     },
     "@sinonjs/commons": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
-      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "@sinonjs/samsam": "^2 || ^3"
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
-      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
-      "dev": true
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+      "integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
+      }
     },
     "@types/node": {
       "version": "8.10.8",
@@ -352,6 +357,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-includes": {
@@ -3360,9 +3371,9 @@
       }
     },
     "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
     "keyboardevent-from-electron-accelerator": {
@@ -3531,9 +3542,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
-      "integrity": "sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
       "dev": true
     },
     "loose-envify": {
@@ -3725,16 +3736,24 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
-      "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
       }
     },
     "normalize-package-data": {
@@ -7241,12 +7260,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "dev": true
-    },
     "sanitize-filename": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
@@ -7312,26 +7325,24 @@
       }
     },
     "sinon": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.5.tgz",
-      "integrity": "sha512-TcbRoWs1SdY6NOqfj0c9OEQquBoZH+qEf8799m1jjcbfWrrpyCQ3B/BpX7+NKa7Vn33Jl+Z50H4Oys3bzygK2Q==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.2.tgz",
+      "integrity": "sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.1",
-        "@sinonjs/formatio": "^2.0.0",
-        "@sinonjs/samsam": "^2.0.0",
+        "@sinonjs/commons": "^1.2.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.2",
         "diff": "^3.5.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.7.1",
-        "nise": "^1.4.2",
-        "supports-color": "^5.4.0",
-        "type-detect": "^4.0.8"
+        "lolex": "^3.0.0",
+        "nise": "^1.4.7",
+        "supports-color": "^5.5.0"
       },
       "dependencies": {
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -8041,7 +8052,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "body": "^5.1.0",
     "fast-isnumeric": "^1.1.2",
-    "file-type": "^9.0.0",
+    "file-type": "^10.7.0",
     "get-stdin": "^5.0.1",
     "glob": "^7.1.3",
     "is-plain-obj": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -90,9 +90,9 @@
     "electron-debug": "^1.4.0",
     "image-size": "^0.6.3",
     "sinon": "^6.1.5",
-    "snazzy": "^7.0.0",
+    "snazzy": "^8.0.0",
     "spectron": "^3.8.0",
-    "standard": "^11.0.1",
+    "standard": "^12.0.1",
     "tap": "^12.1.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "cross-env": "^5.1.4",
+    "cross-env": "^5.2.0",
     "devtron": "^1.4.0",
     "electron": "^1.8.4",
     "electron-builder": "^20.9.2",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "run-parallel": "^1.1.9",
     "run-parallel-limit": "^1.0.5",
     "run-series": "^1.1.8",
-    "semver": "^5.4.1",
+    "semver": "^5.6.0",
     "string-to-stream": "^1.1.1",
     "tinycolor2": "^1.4.1",
     "uuid": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jsdom": "11.12.0",
     "minimist": "^1.2.0",
     "pngjs": "^3.3.3",
-    "read-chunk": "^2.1.0",
+    "read-chunk": "^3.0.0",
     "request": "^2.88.0",
     "run-parallel": "^1.1.9",
     "run-parallel-limit": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "electron-builder": "^20.9.2",
     "electron-debug": "^1.4.0",
     "image-size": "^0.6.3",
-    "sinon": "^6.1.5",
+    "sinon": "^7.2.2",
     "snazzy": "^8.0.0",
     "spectron": "^3.8.0",
     "standard": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "npm run test:lint && npm run test:unit && npm run test:integration",
     "coverage": "npm run test:unit -- --cov",
     "lint": "standard --fix",
-    "pack": "cross-env NODE_ENV=production electron-builder --publish=never"
+    "pack": "cross-env NODE_ENV=production electron-builder --publish=never",
+    "postshrinkwrap": "replace --silent '\"resolved\": \"http://' '\"resolved\": \"https://' package-lock.json"
   },
   "build": {
     "appId": "com.plotly.orca",
@@ -89,6 +90,7 @@
     "electron-builder": "^20.9.2",
     "electron-debug": "^1.4.0",
     "image-size": "^0.6.3",
+    "replace": "^1.0.1",
     "sinon": "^7.2.2",
     "snazzy": "^8.0.0",
     "spectron": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -63,10 +63,10 @@
   ],
   "dependencies": {
     "body": "^5.1.0",
-    "fast-isnumeric": "^1.1.1",
+    "fast-isnumeric": "^1.1.2",
     "file-type": "^9.0.0",
     "get-stdin": "^5.0.1",
-    "glob": "^7.1.2",
+    "glob": "^7.1.3",
     "is-plain-obj": "^1.1.0",
     "is-url": "^1.2.4",
     "jsdom": "11.12.0",
@@ -93,7 +93,7 @@
     "snazzy": "^7.0.0",
     "spectron": "^3.8.0",
     "standard": "^11.0.1",
-    "tap": "^12.0.1"
+    "tap": "^12.1.1"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/src/app/runner/get-body.js
+++ b/src/app/runner/get-body.js
@@ -27,7 +27,7 @@ function getBody (item, cb) {
         return cb(e)
       }
 
-      const body = Object.assign({}, item, {figure: figure})
+      const body = Object.assign({}, item, { figure: figure })
       cb(err, body)
     }
   } else {

--- a/src/app/runner/index.js
+++ b/src/app/runner/index.js
@@ -1,5 +1,5 @@
-const {app, BrowserWindow} = require('electron')
-const {ipcMain} = require('electron')
+const { app, BrowserWindow } = require('electron')
+const { ipcMain } = require('electron')
 
 const initApp = require('../../util/init-app')
 const createIndex = require('../../util/create-index')

--- a/src/app/server/create-server.js
+++ b/src/app/server/create-server.js
@@ -37,7 +37,7 @@ function createServer (app, BrowserWindow, ipcMain, opts) {
     }
 
     const simpleReply = (code, msg) => {
-      res.writeHead(code, {'Content-Type': 'text/plain'})
+      res.writeHead(code, { 'Content-Type': 'text/plain' })
       return res.end(msg || STATUS_MSG[code])
     }
 
@@ -45,7 +45,7 @@ function createServer (app, BrowserWindow, ipcMain, opts) {
       fullInfo.msg = fullInfo.msg || STATUS_MSG[code] || ''
 
       app.emit('export-error', Object.assign(
-        {code: code},
+        { code: code },
         fullInfo
       ))
 
@@ -143,7 +143,7 @@ function createServer (app, BrowserWindow, ipcMain, opts) {
     })
 
     // parse -> send to renderer GO!
-    textBody(req, {limit: BUFFER_OVERFLOW_LIMIT}, (err, _body) => {
+    textBody(req, { limit: BUFFER_OVERFLOW_LIMIT }, (err, _body) => {
       let body
 
       if (err) {

--- a/src/app/server/index.js
+++ b/src/app/server/index.js
@@ -1,5 +1,5 @@
-const {app, BrowserWindow} = require('electron')
-const {ipcMain} = require('electron')
+const { app, BrowserWindow } = require('electron')
+const { ipcMain } = require('electron')
 // require('electron-debug')({showDevTools: true})
 
 const initApp = require('../../util/init-app')

--- a/src/component/plotly-dash-preview/constants.js
+++ b/src/component/plotly-dash-preview/constants.js
@@ -6,12 +6,12 @@ module.exports = {
   maxRenderingTries: 100,
   pixelsInMicron: pixelsInInch / micronsInInch,
   sizeMapping: {
-    'A3': {'width': 11.7 * pixelsInInch, 'height': 16.5 * pixelsInInch},
-    'A4': {'width': 8.3 * pixelsInInch, 'height': 11.7 * pixelsInInch},
-    'A5': {'width': 5.8 * pixelsInInch, 'height': 8.3 * pixelsInInch},
-    'Letter': {'width': 8.5 * pixelsInInch, 'height': 11 * pixelsInInch},
-    'Legal': {'width': 8.5 * pixelsInInch, 'height': 14 * pixelsInInch},
-    'Tabloid': {'width': 11 * pixelsInInch, 'height': 17 * pixelsInInch}
+    'A3': { 'width': 11.7 * pixelsInInch, 'height': 16.5 * pixelsInInch },
+    'A4': { 'width': 8.3 * pixelsInInch, 'height': 11.7 * pixelsInInch },
+    'A5': { 'width': 5.8 * pixelsInInch, 'height': 8.3 * pixelsInInch },
+    'Letter': { 'width': 8.5 * pixelsInInch, 'height': 11 * pixelsInInch },
+    'Legal': { 'width': 8.5 * pixelsInInch, 'height': 14 * pixelsInInch },
+    'Tabloid': { 'width': 11 * pixelsInInch, 'height': 17 * pixelsInInch }
   },
   statusMsg: {
     525: 'dash preview generation failed',

--- a/src/component/plotly-dashboard-preview/parse.js
+++ b/src/component/plotly-dashboard-preview/parse.js
@@ -60,7 +60,7 @@ function parse (body, opts, sendToRenderer) {
           contents: {
             data: [],
             layout: {},
-            annotations: [{text: cont.text ? cont.text.substr(50) : ''}]
+            annotations: [{ text: cont.text ? cont.text.substr(50) : '' }]
           }
         }
 

--- a/src/component/plotly-graph/convert.js
+++ b/src/component/plotly-graph/convert.js
@@ -47,7 +47,7 @@ function convert (info, opts, reply) {
       ? opts.pdftops
       : new Pdftops(opts.pdftops)
 
-    pdftops.pdf2eps(pdf, {id: info.id}, (err, eps) => {
+    pdftops.pdf2eps(pdf, { id: info.id }, (err, eps) => {
       if (err) {
         errorCode = 530
         result.error = err
@@ -70,7 +70,7 @@ function convert (info, opts, reply) {
       return done()
     }
 
-    inkscape.svg2emf(svg, {id: info.id, figure: info.figure}, (err, emf) => {
+    inkscape.svg2emf(svg, { id: info.id, figure: info.figure }, (err, emf) => {
       if (err) {
         errorCode = 530
         result.error = err

--- a/src/component/plotly-graph/render.js
+++ b/src/component/plotly-graph/render.js
@@ -68,7 +68,7 @@ function render (info, opts, sendToMain) {
 
   if (semver.gte(Plotly.version, '1.30.0')) {
     promise = Plotly
-      .toImage({data: figure.data, layout: figure.layout, config: config}, imgOpts)
+      .toImage({ data: figure.data, layout: figure.layout, config: config }, imgOpts)
       .then((imgData) => {
         if (PRINT_TO_PDF) {
           return toPDF(imgData, imgOpts, bgColor)

--- a/src/component/plotly-thumbnail/parse.js
+++ b/src/component/plotly-thumbnail/parse.js
@@ -27,7 +27,7 @@ function overrideFigure (figure) {
 
   // remove title, margins and legend
   layout.title = ''
-  layout.margin = {t: 0, b: 0, l: 0, r: 0}
+  layout.margin = { t: 0, b: 0, l: 0, r: 0 }
   layout.showlegend = false
 
   // remove all annotations

--- a/src/util/init-pings.js
+++ b/src/util/init-pings.js
@@ -1,4 +1,4 @@
-const {ipcRenderer} = require('electron')
+const { ipcRenderer } = require('electron')
 
 /** Small wrapper that registers ipc listeners for all components
  *  on channels based on the component name.

--- a/src/util/init-renderers.js
+++ b/src/util/init-renderers.js
@@ -1,4 +1,4 @@
-const {ipcRenderer} = require('electron')
+const { ipcRenderer } = require('electron')
 
 /** Small wrapper that registers ipc listeners for all components
  *  on channels given by their component name.

--- a/src/util/pdftops.js
+++ b/src/util/pdftops.js
@@ -62,7 +62,7 @@ class Pdftops {
    */
   static isPdftopsInstalled () {
     try {
-      childProcess.execSync(`${this.cmdBase} -v`, {stdio: 'ignore'})
+      childProcess.execSync(`${this.cmdBase} -v`, { stdio: 'ignore' })
     } catch (e) {
       return false
     }

--- a/test/integration/orca_serve_graph-only_test.js
+++ b/test/integration/orca_serve_graph-only_test.js
@@ -44,7 +44,7 @@ tap.test('should work for *plotly-graph* component', t => {
     body: JSON.stringify({
       figure: {
         layout: {
-          data: [{y: [1, 2, 1]}]
+          data: [{ y: [1, 2, 1] }]
         }
       }
     })
@@ -64,7 +64,7 @@ tap.test('should not work for *plotly-thumbnail* component', t => {
     body: JSON.stringify({
       figure: {
         layout: {
-          data: [{y: [1, 2, 1]}]
+          data: [{ y: [1, 2, 1] }]
         }
       }
     })

--- a/test/integration/orca_serve_test.js
+++ b/test/integration/orca_serve_test.js
@@ -48,7 +48,7 @@ tap.test('should work for *plotly-graph* component', t => {
     body: JSON.stringify({
       figure: {
         layout: {
-          data: [{y: [1, 2, 1]}]
+          data: [{ y: [1, 2, 1] }]
         }
       }
     })
@@ -70,7 +70,7 @@ tap.test('should work for *plotly-thumbnail* component', t => {
     body: JSON.stringify({
       figure: {
         layout: {
-          data: [{y: [1, 2, 1]}]
+          data: [{ y: [1, 2, 1] }]
         }
       }
     })
@@ -83,7 +83,7 @@ tap.test('should work for *plotly-thumbnail* component', t => {
   })
 })
 
-tap.test('should work for *plotly-dashboard* component', {timeout: 1e5}, t => {
+tap.test('should work for *plotly-dashboard* component', { timeout: 1e5 }, t => {
   t.test('responding with correct status code and body type', t => {
     request({
       method: 'POST',

--- a/test/unit/coerce-component_test.js
+++ b/test/unit/coerce-component_test.js
@@ -9,7 +9,7 @@ const coerceComponent = require('../../src/util/coerce-component')
 
 const testMockComponentModule = (t, compModuleContent, cb) => {
   const compPath = path.join(paths.build, uuid() + '.js')
-  const comp = {path: compPath}
+  const comp = { path: compPath }
 
   fs.writeFile(compPath, compModuleContent, (err) => {
     if (err) fs.unlink(compPath, t.fail)
@@ -22,9 +22,9 @@ const testMockComponentModule = (t, compModuleContent, cb) => {
 tap.test('should fill defaults and reference to module', t => {
   const areEquivalent = [
     () => coerceComponent('plotly-graph'),
-    () => coerceComponent({name: 'plotly-graph'}),
-    () => coerceComponent({name: 'plotly-graph', options: {plotlyJS: 'v1.20.0'}}),
-    () => coerceComponent({path: path.join(__dirname, '..', '..', 'src', 'component', 'plotly-graph')})
+    () => coerceComponent({ name: 'plotly-graph' }),
+    () => coerceComponent({ name: 'plotly-graph', options: { plotlyJS: 'v1.20.0' } }),
+    () => coerceComponent({ path: path.join(__dirname, '..', '..', 'src', 'component', 'plotly-graph') })
   ]
 
   areEquivalent.forEach((fn, i) => {
@@ -59,7 +59,7 @@ tap.test('should return null on non-string and non-object input', t => {
 
 tap.test('should return null when path to component is not found', t => {
   t.test('when component has no *path* or *name* key', t => {
-    const shouldFail = [{}, {nopath: 'p', noname: 'n'}]
+    const shouldFail = [{}, { nopath: 'p', noname: 'n' }]
 
     shouldFail.forEach(d => {
       t.test(`(input ${JSON.stringify(d)})`, t => {
@@ -72,7 +72,7 @@ tap.test('should return null when path to component is not found', t => {
   })
 
   t.test('when *path* does not resolve', t => {
-    t.equal(coerceComponent({path: 'not/gonna/work'}), null)
+    t.equal(coerceComponent({ path: 'not/gonna/work' }), null)
     t.end()
   })
 
@@ -116,9 +116,9 @@ tap.test('should return null if module is invalid', t => {
 
 tap.test('should normalize *route*', t => {
   const areEquivalent = [
-    () => coerceComponent({name: 'plotly-graph'}),
-    () => coerceComponent({name: 'plotly-graph', route: '/plotly-graph'}),
-    () => coerceComponent({name: 'plotly-graph', route: 'plotly-graph'})
+    () => coerceComponent({ name: 'plotly-graph' }),
+    () => coerceComponent({ name: 'plotly-graph', route: '/plotly-graph' }),
+    () => coerceComponent({ name: 'plotly-graph', route: 'plotly-graph' })
   ]
 
   areEquivalent.forEach((fn, i) => {
@@ -160,21 +160,21 @@ tap.test('should log info on debug', t => {
   })
 
   t.test('should log when non-string/non-object component are passed', t => {
-    coerceComponent(null, {debug: true})
+    coerceComponent(null, { debug: true })
     t.ok(console.warn.calledOnce)
     t.match(console.warn.args[0], /^non-string, non-object component passed/)
     t.end()
   })
 
   t.test('should log when path to component is not set', t => {
-    coerceComponent({nopath: 'p'}, {debug: true})
+    coerceComponent({ nopath: 'p' }, { debug: true })
     t.ok(console.warn.calledOnce)
     t.match(console.warn.args[0], /^path to component not found/)
     t.end()
   })
 
   t.test('should log MODULE_NOT_FOUND error when *require(comp.path)* fails', t => {
-    coerceComponent({path: 'not/gonna/work'}, {debug: true})
+    coerceComponent({ path: 'not/gonna/work' }, { debug: true })
     t.ok(console.warn.calledOnce)
     t.match(console.warn.args[0][0].code, /MODULE_NOT_FOUND/)
     t.end()
@@ -188,7 +188,7 @@ tap.test('should log info on debug', t => {
     }`
 
     testMockComponentModule(t, content, (comp) => {
-      coerceComponent(comp, {debug: true})
+      coerceComponent(comp, { debug: true })
       t.ok(console.warn.calledOnce)
       t.match(console.warn.args[0], /^invalid component module/)
     })

--- a/test/unit/create-index_test.js
+++ b/test/unit/create-index_test.js
@@ -61,7 +61,7 @@ tap.test('should log path to created index in debug mode', t => {
   })
 
   t.test('(debug mode)', t => {
-    fn({debug: true}, (index) => {
+    fn({ debug: true }, (index) => {
       t.ok(console.log.calledOnce)
       t.match(console.log.args[0], /^created index/)
       t.end()

--- a/test/unit/inkscape_test.js
+++ b/test/unit/inkscape_test.js
@@ -12,7 +12,7 @@ tap.test('inkscape.svg2emf', t => {
     const inkscape = new Inkscape()
     const outPath = path.join(paths.build, 'inkscape-test.emf')
 
-    inkscape.svg2emf(mocks.svg, {figure: mocks.figure}, (err, result) => {
+    inkscape.svg2emf(mocks.svg, { figure: mocks.figure }, (err, result) => {
       if (err) t.fail(err)
       t.type(result, Buffer)
 
@@ -31,7 +31,7 @@ tap.test('inkscape.svg2emf', t => {
     const tmpOutPath = path.join(paths.build, 'tmp-emf')
     const tmpSvgPath = path.join(paths.build, 'tmp-svg')
 
-    inkscape.svg2emf(mocks.svg, {id: 'tmp', figure: mocks.figure}, (err, result) => {
+    inkscape.svg2emf(mocks.svg, { id: 'tmp', figure: mocks.figure }, (err, result) => {
       if (err) t.fail(err)
 
       t.type(result, Buffer)
@@ -47,7 +47,7 @@ tap.test('inkscape.svg2emf', t => {
     const tmpOutPath = path.join(paths.build, 'tmp-emf')
     const tmpSvgPath = path.join(paths.build, 'tmp-svg')
 
-    inkscape.svg2emf(mocks.svg, {id: 'tmp', figure: mocks.figure}, (err) => {
+    inkscape.svg2emf(mocks.svg, { id: 'tmp', figure: mocks.figure }, (err) => {
       t.throws(() => { throw err }, /Command failed/)
       t.notOk(fs.existsSync(tmpOutPath), 'clears tmp emf file')
       t.notOk(fs.existsSync(tmpSvgPath), 'clears tmp svg file')

--- a/test/unit/pdftops_test.js
+++ b/test/unit/pdftops_test.js
@@ -35,7 +35,7 @@ tap.test('pdftops.pdf2eps', t => {
     const tmpOutPath = path.join(paths.build, 'tmp-eps')
     const tmpSvgPath = path.join(paths.build, 'tmp-pdf')
 
-    pdftops.pdf2eps(mocks.pdf, {id: 'tmp'}, (err, result) => {
+    pdftops.pdf2eps(mocks.pdf, { id: 'tmp' }, (err, result) => {
       if (err) t.fail(err)
 
       t.type(result, Buffer)
@@ -51,7 +51,7 @@ tap.test('pdftops.pdf2eps', t => {
     const tmpOutPath = path.join(paths.build, 'tmp-eps')
     const tmpSvgPath = path.join(paths.build, 'tmp-pdf')
 
-    pdftops.pdf2eps(mocks.pdf, {id: 'tmp'}, (err) => {
+    pdftops.pdf2eps(mocks.pdf, { id: 'tmp' }, (err) => {
       t.throws(() => { throw err }, /Command failed/)
       t.notOk(fs.existsSync(tmpOutPath), 'clears tmp eps file')
       t.notOk(fs.existsSync(tmpSvgPath), 'clears tmp pdf file')

--- a/test/unit/plotly-dash-preview_test.js
+++ b/test/unit/plotly-dash-preview_test.js
@@ -13,9 +13,9 @@ tap.test('parse:', t => {
 
     shouldFail.forEach(d => {
       t.test(`(case ${JSON.stringify(d)})`, t => {
-        fn({url: d}, {}, (errorCode, result) => {
+        fn({ url: d }, {}, (errorCode, result) => {
           t.equal(errorCode, 400)
-          t.same(result, {'msg': 'invalid url'})
+          t.same(result, { 'msg': 'invalid url' })
           t.end()
         })
       })
@@ -24,7 +24,7 @@ tap.test('parse:', t => {
     t.end()
   })
   t.test('should error when neither loading_selector or timeout is given', t => {
-    fn({url: 'https://dash-app.com'}, {}, (errorCode, result) => {
+    fn({ url: 'https://dash-app.com' }, {}, (errorCode, result) => {
       t.equal(errorCode, 400)
       t.equal(result.msg, 'either selector or timeout must be specified')
       t.end()
@@ -45,7 +45,7 @@ tap.test('parse:', t => {
     fn({
       url: 'https://dash-app.com',
       selector: 'dummy',
-      pageSize: {height: 1000, width: 1000}
+      pageSize: { height: 1000, width: 1000 }
     }, {}, (errorCode, result) => {
       t.equal(errorCode, null)
 
@@ -61,12 +61,12 @@ tap.test('parse:', t => {
     fn({
       url: 'https://dash-app.com',
       selector: 'dummy',
-      pdf_options: {pageSize: 'Letter', marginsType: 1}
+      pdf_options: { pageSize: 'Letter', marginsType: 1 }
     }, {}, (errorCode, result) => {
       t.equal(errorCode, null)
       // height/width are converted to pixels from page-type:
-      t.same(result.browserSize, {height: 1056, width: 816})
-      t.same(result.pdfOptions, {pageSize: 'Letter', marginsType: 1})
+      t.same(result.browserSize, { height: 1056, width: 816 })
+      t.same(result.pdfOptions, { pageSize: 'Letter', marginsType: 1 })
       t.end()
     })
   })
@@ -127,7 +127,7 @@ tap.test('render:', t => {
       t.ok(win.webContents.printToPDF.notCalled)
       t.ok(win.close.calledOnce)
       t.equal(errorCode, 526, 'code')
-      t.same(result, {'msg': 'dash preview generation timed out'}, 'result')
+      t.same(result, { 'msg': 'dash preview generation timed out' }, 'result')
       t.end()
     })
   })

--- a/test/unit/plotly-dashboard_test.js
+++ b/test/unit/plotly-dashboard_test.js
@@ -14,7 +14,7 @@ tap.test('parse:', t => {
 
     shouldFail.forEach(d => {
       t.test(`(case ${JSON.stringify(d)})`, t => {
-        fn({url: d}, {}, (errorCode, result) => {
+        fn({ url: d }, {}, (errorCode, result) => {
           t.equal(errorCode, 400, 'code')
           t.end()
         })

--- a/test/unit/plotly-graph_test.js
+++ b/test/unit/plotly-graph_test.js
@@ -17,7 +17,7 @@ tap.test('inject:', t => {
   })
 
   t.test('should add mathjax script if given with config options', t => {
-    const out = fn({mathjax: 'http://dummy.url'})
+    const out = fn({ mathjax: 'http://dummy.url' })
 
     t.same(out, [
       '<script src="http://dummy.url?config=TeX-AMS-MML_SVG"></script>',
@@ -27,7 +27,7 @@ tap.test('inject:', t => {
   })
 
   t.test('should add topojson script if given', t => {
-    const out = fn({topojson: 'http://dummy.url'})
+    const out = fn({ topojson: 'http://dummy.url' })
 
     t.same(out, [
       '<script src="http://dummy.url"></script>',
@@ -38,7 +38,7 @@ tap.test('inject:', t => {
 
   t.test('should accept plotly.js version to be specify via semver', t => {
     const _fn = (arg, src) => {
-      t.same(fn({plotlyJS: arg}), [`<script src="https://cdn.plot.ly/plotly-${src}.min.js"></script>`])
+      t.same(fn({ plotlyJS: arg }), [`<script src="https://cdn.plot.ly/plotly-${src}.min.js"></script>`])
     }
 
     _fn('v1.20.0', '1.20.0')
@@ -48,31 +48,31 @@ tap.test('inject:', t => {
   })
 
   t.test('should accept plotly.js version to be specify via url', t => {
-    const out = fn({plotlyJS: 'http://dummy.url'})
+    const out = fn({ plotlyJS: 'http://dummy.url' })
 
     t.same(out, ['<script src="http://dummy.url"></script>'])
     t.end()
   })
 
   t.test('should accept path to plotly.js bundle', t => {
-    const out = fn({plotlyJS: paths.readme})
+    const out = fn({ plotlyJS: paths.readme })
 
     t.match(out[0], /README.md/)
     t.end()
   })
 
   t.test('should throw when given plotly.js argument is invalid', t => {
-    t.throws(() => fn({plotlyJS: 'not gonna work'}))
+    t.throws(() => fn({ plotlyJS: 'not gonna work' }))
     t.end()
   })
 
   t.test('should throw when given mathjax argument is invalid', t => {
-    t.throws(() => fn({mathjax: 'not gonna work'}))
+    t.throws(() => fn({ mathjax: 'not gonna work' }))
     t.end()
   })
 
   t.test('should throw when given topojson argument is invalid', t => {
-    t.throws(() => fn({topojson: 'not gonna work'}))
+    t.throws(() => fn({ topojson: 'not gonna work' }))
     t.end()
   })
 
@@ -85,7 +85,7 @@ tap.test('parse:', t => {
   t.test('should fill in defaults', t => {
     const body = {
       figure: {
-        data: [{y: [1, 2, 1]}]
+        data: [{ y: [1, 2, 1] }]
       }
     }
 
@@ -93,7 +93,7 @@ tap.test('parse:', t => {
       t.equal(errorCode, null, 'code')
       t.same(result, {
         figure: {
-          data: [{y: [1, 2, 1]}],
+          data: [{ y: [1, 2, 1] }],
           layout: {}
         },
         format: 'png',
@@ -116,7 +116,7 @@ tap.test('parse:', t => {
     const _fn = (d, cb) => {
       const body = {
         format: d,
-        figure: {data: [{y: [1, 2, 1]}]}
+        figure: { data: [{ y: [1, 2, 1] }] }
       }
       fn(body, {}, cb)
     }
@@ -156,12 +156,12 @@ tap.test('parse:', t => {
 
   t.test('parsing *figure*', t => {
     const shouldFail = [
-      {}, [], 123, '', {nodata: [], nolayout: {}}
+      {}, [], 123, '', { nodata: [], nolayout: {} }
     ]
 
     shouldFail.forEach(d => {
       t.test(`should error for ${JSON.stringify(d)}`, t => {
-        fn({figure: d}, {}, (errorCode, result) => {
+        fn({ figure: d }, {}, (errorCode, result) => {
           t.equal(errorCode, 400)
           t.end()
         })
@@ -174,7 +174,7 @@ tap.test('parse:', t => {
   t.test('parsing *data*', t => {
     t.test('should default to empty array if not set', t => {
       const body = {
-        figure: {layout: {}}
+        figure: { layout: {} }
       }
       fn(body, {}, (errorCode, result) => {
         t.equal(errorCode, null, 'code')
@@ -188,7 +188,7 @@ tap.test('parse:', t => {
     shouldFail.forEach(d => {
       t.test(`should error for ${JSON.stringify(d)}`, t => {
         const body = {
-          figure: {data: d, layout: {}}
+          figure: { data: d, layout: {} }
         }
         fn(body, {}, (errorCode, result) => {
           t.equal(errorCode, 400, 'code')
@@ -204,7 +204,7 @@ tap.test('parse:', t => {
   t.test('parsing *layout*', t => {
     t.test('should default to empty object if not set', t => {
       const body = {
-        figure: {data: []}
+        figure: { data: [] }
       }
       fn(body, {}, (errorCode, result) => {
         t.equal(errorCode, null, 'code')
@@ -218,7 +218,7 @@ tap.test('parse:', t => {
     shouldFail.forEach(d => {
       t.test(`should error for ${JSON.stringify(d)}`, t => {
         const body = {
-          figure: {data: [], layout: d}
+          figure: { data: [], layout: d }
         }
         fn(body, {}, (errorCode, result) => {
           t.equal(errorCode, 400, 'code')
@@ -237,11 +237,11 @@ tap.test('parse:', t => {
     const shouldFail = [undefined, '', -12, null, false]
 
     keys.forEach(k => {
-      const dflt = {width: 700, height: 500}[k]
+      const dflt = { width: 700, height: 500 }[k]
 
       shouldPass.forEach(d => {
         t.test(`should accept ${d}`, t => {
-          const body = {figure: {data: []}}
+          const body = { figure: { data: [] } }
           body[k] = d
 
           fn(body, {}, (errorCode, result) => {
@@ -254,7 +254,7 @@ tap.test('parse:', t => {
 
       shouldPass.forEach(d => {
         t.test(`should fallback to dflt for ${d} with autosize turned on`, t => {
-          const body = {figure: {data: [], layout: { autosize: true }}}
+          const body = { figure: { data: [], layout: { autosize: true } } }
           body.figure.layout[k] = d
 
           fn(body, {}, (errorCode, result) => {
@@ -267,7 +267,7 @@ tap.test('parse:', t => {
 
       shouldFail.forEach(d => {
         t.test(`should fallback to layout ${k} for ${d}`, t => {
-          const body = {figure: {data: [], layout: {}}}
+          const body = { figure: { data: [], layout: {} } }
           body[k] = d
           body.figure.layout[k] = 1000
 
@@ -279,7 +279,7 @@ tap.test('parse:', t => {
         })
 
         t.test(`should fallback to dflt for ${d} with invalid layout ${k}`, t => {
-          const body = {figure: {data: [], layout: {}}}
+          const body = { figure: { data: [], layout: {} } }
           body[k] = d
           body.figure.layout[k] = d
 
@@ -297,8 +297,8 @@ tap.test('parse:', t => {
 
   t.test('should work with component options too', t => {
     const body = {
-      data: [{y: [1, 2, 1]}],
-      layout: {height: 200}
+      data: [{ y: [1, 2, 1] }],
+      layout: { height: 200 }
     }
 
     const opts = {
@@ -312,8 +312,8 @@ tap.test('parse:', t => {
       t.equal(errorCode, null, 'code')
       t.same(result, {
         figure: {
-          data: [{y: [1, 2, 1]}],
-          layout: {height: 200}
+          data: [{ y: [1, 2, 1] }],
+          layout: { height: 200 }
         },
         format: 'svg',
         scale: 2,
@@ -335,7 +335,7 @@ tap.test('parse:', t => {
           type: 'scatter',
           x: x
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -350,7 +350,7 @@ tap.test('parse:', t => {
           type: 'scattergl',
           x: x
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, null, 'code')
         t.type(result.figure, 'object', 'figure type')
         t.end()
@@ -369,7 +369,7 @@ tap.test('parse:', t => {
             values: x
           }]
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -388,7 +388,7 @@ tap.test('parse:', t => {
           type: 'heatmap',
           z: z
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -407,7 +407,7 @@ tap.test('parse:', t => {
             ]
           }
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -419,7 +419,7 @@ tap.test('parse:', t => {
 
       fn({
         data: data
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -433,7 +433,7 @@ tap.test('parse:', t => {
           x: new Array(1e5),
           boxpoints: 'all'
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -447,7 +447,7 @@ tap.test('parse:', t => {
           x: new Array(1e5),
           points: 'all'
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -463,7 +463,7 @@ tap.test('parse:', t => {
           x: data,
           alphahull: 1
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -475,7 +475,7 @@ tap.test('parse:', t => {
 
       fn({
         data: data
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -494,7 +494,7 @@ tap.test('parse:', t => {
             new Array(4e5)
           ]
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -512,7 +512,7 @@ tap.test('parse:', t => {
           boxpoints: 'all',
           x: new Array(4e4) // below 5e4 threshold
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -525,7 +525,7 @@ tap.test('parse:', t => {
           type: 'scatter',
           x: new Array(1e6)
         }]
-      }, {safeMode: true}, (errorCode, result) => {
+      }, { safeMode: true }, (errorCode, result) => {
         t.equal(errorCode, 400, 'code')
         t.type(result.msg, 'string', 'msg type')
         t.end()
@@ -546,7 +546,7 @@ tap.test('convert:', t => {
 
     formats.forEach(f => {
       t.test(`for format ${f}`, t => {
-        fn({imgData: 'asdfDFDASFsafadsf', format: f}, {}, (errorCode, result) => {
+        fn({ imgData: 'asdfDFDASFsafadsf', format: f }, {}, (errorCode, result) => {
           t.equal(errorCode, null)
           t.match(result.head['Content-Type'], f)
           t.type(result.body, Buffer)
@@ -564,7 +564,7 @@ tap.test('convert:', t => {
 
     formats.forEach(f => {
       t.test(`for format ${f}`, t => {
-        fn({imgData: 'asdfDFDASFsafadsf', format: f, encoded: true}, {}, (errorCode, result) => {
+        fn({ imgData: 'asdfDFDASFsafadsf', format: f, encoded: true }, {}, (errorCode, result) => {
           t.equal(errorCode, null)
           t.match(result.head['Content-Type'], f)
           t.type(result.body, 'asdfDFDASFsafadsf')
@@ -575,7 +575,7 @@ tap.test('convert:', t => {
     })
 
     t.test('for format pdf', t => {
-      fn({imgData: 'asdfDFDASFsafadsf', format: 'pdf', encoded: true}, {}, (errorCode, result) => {
+      fn({ imgData: 'asdfDFDASFsafadsf', format: 'pdf', encoded: true }, {}, (errorCode, result) => {
         t.equal(errorCode, null)
         t.match(result.head['Content-Type'], 'pdf')
         t.type(result.body, 'data:application/pdf;base64,asdfDFDASFsafadsf')
@@ -588,7 +588,7 @@ tap.test('convert:', t => {
   })
 
   t.test('should pass svg image data', t => {
-    fn({imgData: '<svg></svg>', format: 'svg'}, {}, (errorCode, result) => {
+    fn({ imgData: '<svg></svg>', format: 'svg' }, {}, (errorCode, result) => {
       t.equal(errorCode, null)
       t.equal(result.head['Content-Type'], 'image/svg+xml')
       t.equal(result.body, '<svg></svg>')
@@ -598,7 +598,7 @@ tap.test('convert:', t => {
   })
 
   t.test('should convert pdf data to eps', t => {
-    const info = {imgData: mocks.pdf, format: 'eps'}
+    const info = { imgData: mocks.pdf, format: 'eps' }
 
     t.test('(encoded false)', t => {
       fn(info, {}, (errorCode, result) => {
@@ -610,7 +610,7 @@ tap.test('convert:', t => {
     })
 
     t.test('(encoded true)', t => {
-      fn(Object.assign({}, info, {encoded: true}), {}, (errorCode, result) => {
+      fn(Object.assign({}, info, { encoded: true }), {}, (errorCode, result) => {
         t.equal(errorCode, null)
         t.equal(result.head['Content-Type'], 'application/postscript')
         t.match(result.body, /^data:application\/postscript;base64,/)
@@ -622,8 +622,8 @@ tap.test('convert:', t => {
   })
 
   t.test('should convert pdf data to eps (while passing instance of Pdftops)', t => {
-    const info = {imgData: mocks.pdf, format: 'eps'}
-    const opts = {pdftops: new Pdftops()}
+    const info = { imgData: mocks.pdf, format: 'eps' }
+    const opts = { pdftops: new Pdftops() }
 
     fn(info, opts, (errorCode, result) => {
       t.equal(errorCode, null)
@@ -634,8 +634,8 @@ tap.test('convert:', t => {
   })
 
   t.test('should pass pdftops errors', t => {
-    const info = {imgData: mocks.pdf, format: 'eps'}
-    const opts = {pdftops: 'not gonna work'}
+    const info = { imgData: mocks.pdf, format: 'eps' }
+    const opts = { pdftops: 'not gonna work' }
 
     fn(info, opts, (errorCode, result) => {
       t.equal(errorCode, 530)
@@ -722,11 +722,11 @@ tap.test('render:', t => {
     t.test('(format pdf)', t => {
       mock130()
       mockBrowser()
-      const {win, restore} = mockWindow()
+      const { win, restore } = mockWindow()
       win.webContents.executeJavaScript.returns(new Promise(resolve => resolve()))
       win.webContents.printToPDF.yields(null, 'pdf data')
 
-      fn({format: 'pdf'}, {}, (errorCode, result) => {
+      fn({ format: 'pdf' }, {}, (errorCode, result) => {
         t.equal(errorCode, null)
         t.equal(result.imgData, 'pdf data')
         t.equal(window.encodeURIComponent.callCount, 1, 'encodeURIComponent calls')
@@ -761,7 +761,7 @@ tap.test('render:', t => {
       mock110()
       mockBrowser()
 
-      fn({encoded: true}, {}, (errorCode, result) => {
+      fn({ encoded: true }, {}, (errorCode, result) => {
         t.equal(result.imgData, 'data:image/yo;base64,image data')
         t.ok(document.createElement.calledOnce)
         t.ok(Plotly.newPlot.calledOnce)
@@ -775,7 +775,7 @@ tap.test('render:', t => {
       mock110()
       mockBrowser()
 
-      fn({format: 'svg'}, {}, (errorCode, result) => {
+      fn({ format: 'svg' }, {}, (errorCode, result) => {
         t.equal(result.imgData, 'decoded image data')
         t.ok(document.createElement.calledOnce)
         t.ok(window.decodeURIComponent.calledOnce)
@@ -790,7 +790,7 @@ tap.test('render:', t => {
       mock110()
       mockBrowser()
 
-      fn({format: 'svg', encoded: true}, {}, (errorCode, result) => {
+      fn({ format: 'svg', encoded: true }, {}, (errorCode, result) => {
         t.equal(result.imgData, 'data:image/yo;base64,image data')
         t.ok(document.createElement.calledOnce)
         t.ok(window.decodeURIComponent.notCalled)
@@ -804,11 +804,11 @@ tap.test('render:', t => {
     t.test('(format pdf)', t => {
       mock110()
       mockBrowser()
-      const {win, restore} = mockWindow()
+      const { win, restore } = mockWindow()
       win.webContents.executeJavaScript.returns(new Promise(resolve => resolve()))
       win.webContents.printToPDF.yields(null, 'pdf data')
 
-      fn({format: 'pdf'}, {}, (errorCode, result) => {
+      fn({ format: 'pdf' }, {}, (errorCode, result) => {
         t.equal(errorCode, null)
         t.equal(result.imgData, 'pdf data')
         t.equal(document.createElement.callCount, 1, 'createElement calls')
@@ -817,7 +817,7 @@ tap.test('render:', t => {
         t.equal(win.webContents.printToPDF.callCount, 1, 'printToPDF calls')
         t.doesNotThrow(() => {
           const gd = {
-            _fullLayout: {paper_bgcolor: 'some color'}
+            _fullLayout: { paper_bgcolor: 'some color' }
           }
           Plotly.toImage.args[0][1].setBackground(gd, 'some other color')
         }, 'custom setBackground function')
@@ -854,12 +854,12 @@ tap.test('render:', t => {
   t.test('should return error code on executeJavaScript errors', t => {
     mock130()
     mockBrowser()
-    const {win, restore} = mockWindow()
+    const { win, restore } = mockWindow()
     win.webContents.executeJavaScript.returns(new Promise((resolve, reject) => {
       reject(new Error('oh no!'))
     }))
 
-    fn({format: 'pdf'}, {}, (errorCode, result) => {
+    fn({ format: 'pdf' }, {}, (errorCode, result) => {
       t.equal(errorCode, 525)
       t.match(result.error, /oh no/, 'error')
       t.ok(win.close.calledOnce)
@@ -872,11 +872,11 @@ tap.test('render:', t => {
   t.test('should return error code on printToPDF errors', t => {
     mock130()
     mockBrowser()
-    const {win, restore} = mockWindow()
+    const { win, restore } = mockWindow()
     win.webContents.executeJavaScript.returns(new Promise(resolve => resolve()))
     win.webContents.printToPDF.yields(new Error('oops'))
 
-    fn({format: 'pdf'}, {}, (errorCode, result) => {
+    fn({ format: 'pdf' }, {}, (errorCode, result) => {
       t.equal(errorCode, 525)
       t.match(result.error, /oops/, 'error')
       t.ok(win.close.calledOnce)
@@ -892,7 +892,7 @@ tap.test('render:', t => {
     formats.forEach(f => {
       t.test(`(format ${f})`, t => {
         mock130()
-        fn({format: f}, {}, () => {
+        fn({ format: f }, {}, () => {
           t.ok(Plotly.toImage.calledOnce)
           t.equal(Plotly.toImage.args[0][1].format, 'svg')
           t.end()
@@ -906,7 +906,7 @@ tap.test('render:', t => {
   t.test('should set setBackground to opaque for jpeg format', t => {
     mock130()
 
-    fn({format: 'jpeg'}, {}, () => {
+    fn({ format: 'jpeg' }, {}, () => {
       t.ok(Plotly.toImage.calledOnce)
       t.equal(Plotly.toImage.args[0][1].setBackground, 'opaque')
       t.end()

--- a/test/unit/plotly-thumbnail_test.js
+++ b/test/unit/plotly-thumbnail_test.js
@@ -18,7 +18,7 @@ tap.test('parse:', t => {
           marker: {}
         }],
         layout: {
-          margin: {l: 100, r: 100, t: 100, b: 100},
+          margin: { l: 100, r: 100, t: 100, b: 100 },
           yaxis: {
             title: 'some title',
             otherAttr: 'dummy'
@@ -65,25 +65,25 @@ tap.test('parse:', t => {
           }, {
             type: 'pie',
             showscale: false,
-            marker: {showscale: false},
+            marker: { showscale: false },
             textposition: 'none'
           }],
           layout: {
             title: '',
             showlegend: false,
-            margin: {b: 0, l: 0, r: 0, t: 0},
+            margin: { b: 0, l: 0, r: 0, t: 0 },
             yaxis: {
               title: '',
               otherAttr: 'dummy'
             },
-            yaxis2: {title: ''},
-            yaxis3: {title: ''},
+            yaxis2: { title: '' },
+            yaxis3: { title: '' },
             xaxis: {
               color: 'blue',
               title: ''
             },
-            xaxis2: {title: ''},
-            xaxis14: {title: ''},
+            xaxis2: { title: '' },
+            xaxis14: { title: '' },
             scene: {
               xaxis: {
                 title: '',

--- a/test/unit/runner_test.js
+++ b/test/unit/runner_test.js
@@ -11,13 +11,13 @@ const { paths, urls } = require('../common')
 tap.test('coerceOpts:', t => {
   t.test('should throw', t => {
     t.test('on blank input', t => {
-      t.throws(() => coerceOpts({component: 'plotly-graph'}), /no valid input given/)
+      t.throws(() => coerceOpts({ component: 'plotly-graph' }), /no valid input given/)
       t.end()
     })
 
     t.test('when no valid component are registered', t => {
       t.throws(() => coerceOpts(), /no valid component registered/)
-      t.throws(() => coerceOpts({input: paths.pkg}), /no valid component registered/)
+      t.throws(() => coerceOpts({ input: paths.pkg }), /no valid component registered/)
       t.end()
     })
 
@@ -134,7 +134,7 @@ tap.test('run:', t => {
   const win = {
     webContents: {
       send: (compName, id, fullInfo, compOpts) => {
-        ipc.emit(id, {}, null, {imgData: 'image data yo!'})
+        ipc.emit(id, {}, null, { imgData: 'image data yo!' })
       }
     },
     close: () => {}
@@ -173,7 +173,7 @@ tap.test('run:', t => {
   })
 
   t.test('should fire *after-export* and *after-export-all* on success', t => {
-    const cases = ['{"data":[{"y":[1,2,1]}]}', {data: [{ y: [1, 2, -1] }]}]
+    const cases = ['{"data":[{"y":[1,2,1]}]}', { data: [{ y: [1, 2, -1] }] }]
 
     cases.forEach(c => {
       t.test(`(case ${c}`, t => {
@@ -239,7 +239,7 @@ tap.test('run:', t => {
       const win = {
         webContents: {
           send: (compName, id, fullInfo, compOpts) => {
-            ipc.emit(id, {}, 555, {msg: 'error msg'})
+            ipc.emit(id, {}, 555, { msg: 'error msg' })
           }
         },
         close: () => {}

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -10,12 +10,12 @@ tap.test('coerceOpts:', t => {
   t.test('should throw', t => {
     t.test('when no valid component are registered', t => {
       t.throws(() => coerceOpts(), /invalid port number/)
-      t.throws(() => coerceOpts({port: 'not gonna work'}), /invalid port number/)
+      t.throws(() => coerceOpts({ port: 'not gonna work' }), /invalid port number/)
       t.end()
     })
 
     t.test('when no valid component are registered', t => {
-      t.throws(() => coerceOpts({port: 20}), /no valid component registered/)
+      t.throws(() => coerceOpts({ port: 20 }), /no valid component registered/)
       t.end()
     })
 
@@ -70,7 +70,7 @@ tap.test('createServer:', t => {
 
   const mockWebContents = (opts, errorCode, result) => {
     errorCode = errorCode || null
-    result = result || {imgData: 'image data yo!'}
+    result = result || { imgData: 'image data yo!' }
 
     opts.component.forEach((comp) => {
       comp._win = {
@@ -87,7 +87,7 @@ tap.test('createServer:', t => {
   }
 
   const BrowserWindow0 = () => ({
-    getAllWindows: () => ({length: 0})
+    getAllWindows: () => ({ length: 0 })
   })
 
   const opts0 = () => coerceOpts({
@@ -244,7 +244,7 @@ tap.test('createServer:', t => {
 
     t.test('when more windows are open than max', t => {
       const BrowserWindow = BrowserWindow0()
-      BrowserWindow.getAllWindows = () => ({length: Infinity})
+      BrowserWindow.getAllWindows = () => ({ length: Infinity })
 
       _boot([false, BrowserWindow], (args) => {
         wrapApp(t, args, [5, 402, 'too many windows are opened'])
@@ -287,7 +287,7 @@ tap.test('createServer:', t => {
     })
 
     t.test('on module render errors', t => {
-      const opts = mockWebContents(opts0(), 467, {msg: 'error msg'})
+      const opts = mockWebContents(opts0(), 467, { msg: 'error msg' })
 
       _boot([false, false, false, opts], (args) => {
         wrapApp(t, args, [12, 467, 'error msg'])


### PR DESCRIPTION
Bumping deps (other than `electron` and `electron-builder` - which will require a PR of their own) that still support Node v6 and our dev deps.

cc @antoinerg 