### PR TITLE
ensure circleci doesn't overwrite Docker images tagged for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,8 +136,8 @@ jobs:
               docker push quay.io/plotly/image-exporter:$version
             fi
 
-            # Is this branch named after a version?
-            if echo $CIRCLE_BRANCH | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$"; then
+            # Is this branch named after a version "x.x.x" or a build release "x.x.xbx" where x are digits
+            if echo $CIRCLE_BRANCH | grep -E "^[0-9]+\.[0-9]+\.[0-9]+(b[0-9]+)?$"; then
               # if so, do NOT push image as branch name to not conflict
               # with images named after version numbers
               echo "WARNING: branch name matches version number regex"


### PR DESCRIPTION
This PR prevents CircleCI from tagging Docker images with names reserved for releases (ie. of the form `x.x.xb.x` where `x` is one or multiple digits).