### PR TITLE
Pass mapboxAccessToken as null to Plotly.toImage when not set

### DIFF
--- a/src/component/plotly-graph/render.js
+++ b/src/component/plotly-graph/render.js
@@ -26,7 +26,7 @@ function render (info, opts, sendToMain) {
   const encoded = info.encoded
 
   const config = Object.assign({
-    mapboxAccessToken: opts.mapboxAccessToken || '',
+    mapboxAccessToken: opts.mapboxAccessToken || null,
     plotGlPixelRatio: opts.plotGlPixelRatio || cst.plotGlPixelRatio
   }, figure.config)
 

--- a/test/unit/plotly-graph_test.js
+++ b/test/unit/plotly-graph_test.js
@@ -913,5 +913,27 @@ tap.test('render:', t => {
     })
   })
 
+  t.test('should pass mapboxAccessToken as config option (string case)', t => {
+    mock130()
+
+    const token = '312dsadsa1321'
+
+    fn({}, { mapboxAccessToken: token }, () => {
+      t.ok(Plotly.toImage.calledOnce)
+      t.equal(Plotly.toImage.args[0][0].config.mapboxAccessToken, token)
+      t.end()
+    })
+  })
+
+  t.test('should pass mapboxAccessToken as config option (empty case)', t => {
+    mock130()
+
+    fn({}, { mapboxAccessToken: '' }, () => {
+      t.ok(Plotly.toImage.calledOnce)
+      t.equal(Plotly.toImage.args[0][0].config.mapboxAccessToken, null)
+      t.end()
+    })
+  })
+
   t.end()
 })


### PR DESCRIPTION
... so that it does not override `layout.mapbox.accesstoken` - fixes https://github.com/plotly/orca/issues/193 cc @antoinerg 