### PR TITLE
Ignore certificate errors if indicated by env var

### DIFF
--- a/deployment/run_server
+++ b/deployment/run_server
@@ -6,6 +6,10 @@ if [[ $PLOTLY_CUSTOM_FONTS_ENABLED = true ]]; then
   fc-cache -v /usr/share/fonts/customer
 fi
 
+if [[ $PLOTLY_IMAGESERVER_IGNORE_CERT_ERRORS = true ]]; then
+  ORCA_IGNORECERTERRORS_ARG="--ignore-certificate-errors"
+fi
+
 BUILD_DIR=/var/www/image-exporter/build
 if [[ -n "${PLOTLY_JS_SRC}" ]]; then
   # Fetch plotly js bundle and save it locally:
@@ -30,7 +34,7 @@ fi
 pkill Xvfb
 pkill node
 
-xvfb-run --auto-servernum --server-args '-screen 0 640x480x24' ./bin/orca.js serve $REQUEST_LIMIT --safe-mode $PLOTLYJS_ARG $@ 1>/proc/1/fd/1 2>/proc/1/fd/2 &
+xvfb-run --auto-servernum --server-args '-screen 0 640x480x24' ./bin/orca.js serve $REQUEST_LIMIT --safe-mode $PLOTLYJS_ARG $ORCA_IGNORECERTERRORS_ARG $@ 1>/proc/1/fd/1 2>/proc/1/fd/2 &
 echo \$! > \$PIDFILE
 
 EOF


### PR DESCRIPTION
Relates to plotly/streambed#11906. I've tested this and confirmed that certificate errors are ignored / PDFs can be rendered from self-signed websites if the environment variable is set as indicated. No change without the environment variable.

FYI @plotly/devops. @etpinard please review for team orca; @joaoalf please review for the devops team.