### PR TITLE
Update keyservers used for nodejs installation

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -23,7 +23,9 @@ RUN set -ex \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
     56730D5401028683275BD23C23EFEFE93C4CFFFE \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info


### PR DESCRIPTION
The new commands come from the current node Dockerfile for Debian Stretch: https://github.com/nodejs/docker-node/blob/daa131d713cf42ae181292471766879f750b5230/10/stretch/Dockerfile

Fixes https://github.com/plotly/orca/issues/209

This passed CI 5 out of 5 times.

@antoinerg I'm still in favour of the updates you're proposing if you see value in them, but this is a much smaller change that I'm comfortable putting onto the `3.0-release` branch.

@jkaplowitz Please review.