### PR TITLE
Merge EMF fix from `3.1-release` into `master`

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -113,8 +113,11 @@ RUN cd /opt && \
 # Install latest stable Inkscape
 RUN apt-get update && apt-get install -y software-properties-common python-software-properties \
     && add-apt-repository -y ppa:inkscape.dev/stable \
-    && apt-get update && apt-get install -y inkscape \
+    && apt-get update && apt-get install -y inkscape=0.92.4+68~ubuntu16.04.1 \
     && rm -rf /var/lib/apt/lists/* && apt-get clean
+
+# Copy Inkscape defaults
+COPY deployment/preferences.xml /root/.config/inkscape/
 
 ####################
 # Download geo-assets (same version as plotly.js extras/)

--- a/deployment/preferences.xml
+++ b/deployment/preferences.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<inkscape
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1">
+  <group
+     id="extensions"
+     org.inkscape.output.emf.FixPPTGrad2Polys="1"
+     org.inkscape.print.emf.FixPPTCharPos="1"
+     org.inkscape.print.emf.FixPPTDashLine="1"
+     org.inkscape.print.emf.FixPPTGrad2Polys="1"
+     org.inkscape.print.emf.FixPPTLinGrad="1"
+     org.inkscape.print.emf.FixPPTPatternAsHatch="1"
+     org.inkscape.print.emf.FixImageRot="1"
+     org.inkscape.print.emf.textToPath="1"
+     org.inkscape.output.emf.FixPPTPatternAsHatch="1"
+     org.inkscape.output.emf.FixPPTLinGrad="1" />
+</inkscape>


### PR DESCRIPTION
Merging `3.1-release` to `master` so the public has access to the EMF fixes. The commits have already been reviewed so just need a rubber stamp

Closes https://github.com/plotly/orca/issues/218

See original PR https://github.com/plotly/orca/pull/220