### PR TITLE
Fix custom pageSize for Dash App Previews

### DIFF
--- a/src/component/plotly-dash-preview/parse.js
+++ b/src/component/plotly-dash-preview/parse.js
@@ -45,8 +45,8 @@ function parse (body, req, opts, sendToRenderer) {
       height: body.pageSize.height * cst.pixelsInMicron
     }
     result.pdfOptions.pageSize = {
-      width: body.pageSize.width,
-      height: body.pageSize.height
+      width: Math.ceil(body.pageSize.width),
+      height: Math.ceil(body.pageSize.height)
     }
   } else {
     return errorOut(

--- a/src/component/plotly-dash-preview/parse.js
+++ b/src/component/plotly-dash-preview/parse.js
@@ -44,6 +44,10 @@ function parse (body, req, opts, sendToRenderer) {
       width: body.pageSize.width * cst.pixelsInMicron,
       height: body.pageSize.height * cst.pixelsInMicron
     }
+    result.pdfOptions.pageSize = {
+      width: body.pageSize.width,
+      height: body.pageSize.height
+    }
   } else {
     return errorOut(
       400,

--- a/test/unit/plotly-dash-preview_test.js
+++ b/test/unit/plotly-dash-preview_test.js
@@ -54,6 +54,10 @@ tap.test('parse:', t => {
         height: 3.779527559055118,
         width: 3.779527559055118
       })
+      t.same(result.pdfOptions.pageSize, {
+        height: 1000,
+        width: 1000
+      })
       t.end()
     })
   })


### PR DESCRIPTION
Part of https://github.com/plotly/streambed/issues/13458

  - [x] Test different size combinations in an on-prem environment.

The custom size is not working because `remote.CreateBrowserWindow` expects the height/width to be "non-strings" (ie integers or floats). This fixes the issue.