### PR TITLE
Add differentiation from orca screen reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ These additional dependencies can be satisfied by installing:
  - The `google-chrome-stable` package from the [Google Linux Software
  Repository](https://www.google.com/linuxrepositories/).
 
+##### Linux Troubleshooting: Server is started but plotly can't connect
+On some linux distributions there is a screen reader package orca. It may be the
+case that Plotly is calling the screen reader instead of this program. If this
+is the case for you, you can either uninstall the screen reader or refer to the
+[Plotly Documentation](https://plot.ly/python/orca-management/#configuring-the-executable)
+to fully qualify the proper path.
+
 ##### Linux Troubleshooting: Headless server configuration
 The Electron runtime requires the presence of an active X11 display server,
 but many server Linux distributions (e.g. Ubuntu Server) do not include X11


### PR DESCRIPTION
There's a package called orca that's a screen reader. I didn't know I had it installed and it took me about three to four hours to figure it out because there is no mention of this on stack overflow or the community forums (at least that I could find). So this simply adds a note about that in the readme. If this is rejected I'd be happy to make and answer a post about this on stackoverflow.

PS this is my first pull request ever so if I'm doing something wrong please tell me.