### PR TITLE
dash-preview: swap browser window's width and height if landscape

### DIFF
--- a/src/component/plotly-dash-preview/parse.js
+++ b/src/component/plotly-dash-preview/parse.js
@@ -65,6 +65,11 @@ function parse (body, req, opts, sendToRenderer) {
     )
   }
 
+  // Change browser size orientation if landscape
+  if (result.pdfOptions.landscape) {
+    result.browserSize = { width: result.browserSize.height, height: result.browserSize.width }
+  }
+
   // BrowserWindow only accepts integer values:
   result.browserSize['width'] = Math.ceil(result.browserSize['width'])
   result.browserSize['height'] = Math.ceil(result.browserSize['height'])


### PR DESCRIPTION
This PR is a follow-up to https://github.com/plotly/orca/pull/250 which makes the browser size equivalent to the page size to make sure figures have correct dimensions and positioning. Although it works well as reported by @ycaokris, it didn't take into account the `landscape` option which led to badly laid out PDFs.

The fix is to simply swap width and height of the browser size when printing in landscape mode.