### PR TITLE
test-image: fix error reporting

### DIFF
--- a/test/image/compare_images
+++ b/test/image/compare_images
@@ -44,7 +44,7 @@ do
   cat "$3/$filename.txt"
 done
 
-CODE=$(grep -R "all: [^0]" "$3/*.txt" | wc -l)
+CODE=$(grep -R "all: [^0]" "$3"/*.txt | wc -l)
 
 echo "$CODE different images"
 exit "$CODE"


### PR DESCRIPTION
Right now on `master`, running test-image on CI will yield:
`grep: build/test_images_diff/*.txt: No such file or directory`. This regression was introduced in 697068a13a470c9b74d644f255fb2f72eeeddeed . The current PR fixes this issue.

In a nutshell, grep doesn't expand glob to match files but the shell will do it if it's not between double-quotes. Note that the script still passes a `shellcheck`.
