### PR TITLE
depend on chromium instead of google-chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ cannot open shared object file: No such file or directory
 These additional dependencies can be satisfied by installing:
  - The `libgtk2.0-0` and `libgconf-2-4` packages from your distribution's
  software repository.
- - The `google-chrome-stable` package from the [Google Linux Software
- Repository](https://www.google.com/linuxrepositories/).
+ - The `chromium-browser` package from your distribution's
+ software repository.
 
 ##### Linux Troubleshooting: Headless server configuration
 The Electron runtime requires the presence of an active X11 display server,

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -114,11 +114,8 @@ COPY deployment/ImageMagickPolicy.xml /etc/ImageMagick-6/policy.xml
 ####################
 # Copy and set up Orca
 
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' && \
-    apt-get update -y && \
-    apt-get install -y google-chrome-stable xvfb poppler-utils git && \
-    rm -rf /var/lib/apt/lists/* && apt-get clean
+RUN apt-get update && apt-get install -y chromium-browser fonts-liberation xvfb poppler-utils git \
+    && rm -rf /var/lib/apt/lists/* && apt-get clean
 
 COPY package.json /var/www/image-exporter/
 COPY package-lock.json /var/www/image-exporter/


### PR DESCRIPTION
This PR closes https://github.com/plotly/orca/issues/185 by removing our dependency to `google-chrome-stable`. We can instead install `chromium-browser` which brings in all the necessary dependencies for `electron` to run properly.

Because `google-chrome-stable` also installs a special font package `fonts-liberation`, so I had to add it to the Dockerfile in order for figures to remain pixel perfect.

