### PR TITLE
Create the correct docker image tags before running automated releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,10 @@ jobs:
           name: Trigger the version upgrade and release build
           command: |
             cd ..
+            ls -lah
+            SANITIZED_BRANCH=$(echo "$CIRCLE_BRANCH" | iconv -t ascii//TRANSLIT | sed -r s/[^a-zA-Z0-9\.]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z)
+            docker tag quay.io/plotly/image-exporter:$CIRCLE_SHA1 quay.io/plotly/image-exporter:${SANITIZED_BRANCH}-sha-${CIRCLE_SHA1}
+            docker tag quay.io/plotly/image-exporter:$CIRCLE_SHA1 quay.io/plotly/image-exporter:$SANITIZED_BRANCH
             if git clone https://${GITHUB_TOKEN}@github.com/plotly/on-prem.git -b ${CIRCLE_BRANCH} > /dev/null; then
               cd on-prem
               ./onprem git:setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
             if git clone https://${GITHUB_TOKEN}@github.com/plotly/on-prem.git -b ${CIRCLE_BRANCH} > /dev/null; then
               cd on-prem
               ./onprem git:setup
-              ./onprem version:update ${CIRCLE_PROJECT_REPONAME} ../${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} image-exporter
+              ./onprem version:update ${CIRCLE_PROJECT_REPONAME} ../project ${CIRCLE_BRANCH} image-exporter
             else
               echo "Could not locate branch ${CIRCLE_BRANCH}"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,6 @@ jobs:
           name: Trigger the version upgrade and release build
           command: |
             cd ..
-            ls -lah
             SANITIZED_BRANCH=$(echo "$CIRCLE_BRANCH" | iconv -t ascii//TRANSLIT | sed -r s/[^a-zA-Z0-9\.]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z)
             docker tag quay.io/plotly/image-exporter:$CIRCLE_SHA1 quay.io/plotly/image-exporter:${SANITIZED_BRANCH}-sha-${CIRCLE_SHA1}
             docker tag quay.io/plotly/image-exporter:$CIRCLE_SHA1 quay.io/plotly/image-exporter:$SANITIZED_BRANCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
             if git clone https://${GITHUB_TOKEN}@github.com/plotly/on-prem.git -b ${CIRCLE_BRANCH} > /dev/null; then
               cd on-prem
               ./onprem git:setup
-              ./onprem version:update ${CIRCLE_PROJECT_REPONAME} ../${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH}
+              ./onprem version:update ${CIRCLE_PROJECT_REPONAME} ../${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} image-exporter
             else
               echo "Could not locate branch ${CIRCLE_BRANCH}"
             fi


### PR DESCRIPTION
This will (hopefully) fix image releases for orca to quay.io. They were previously broken due to a missing local image that was then not pushed to quay.