### PR TITLE
circleci: sanitize docker image tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,9 +182,10 @@ jobs:
               echo "...  quay.io/plotly/image-exporter:$CIRCLE_BRANCH will NOT be pushed to quay.io"
             else
               # otherwise, tag and push as branch name
-              echo "Tag and push image as branch name"
-              docker tag quay.io/plotly/image-exporter:$CIRCLE_SHA1 quay.io/plotly/image-exporter:$CIRCLE_BRANCH
-              docker push quay.io/plotly/image-exporter:$CIRCLE_BRANCH
+              SANITIZED_BRANCH=$(echo "$CIRCLE_BRANCH" | iconv -t ascii//TRANSLIT | sed -r s/[^a-zA-Z0-9\.]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z)
+              echo "Tag and push image as sanitized branch name: $SANITIZED_BRANCH"
+              docker tag quay.io/plotly/image-exporter:$CIRCLE_SHA1 quay.io/plotly/image-exporter:$SANITIZED_BRANCH
+              docker push quay.io/plotly/image-exporter:$SANITIZED_BRANCH
             fi
       - run:
           name: Trigger the version upgrade and release build


### PR DESCRIPTION
This PR will sanitize docker image tags prior to pushing them (remove slashes amongst other things). This is necessary in order for PRs made automatically by `dependabot` to pass the tests (example: https://github.com/plotly/orca/pull/275).