### PR TITLE
Fix build directory permissions

### DIFF
--- a/src/util/create-index.js
+++ b/src/util/create-index.js
@@ -7,7 +7,7 @@ const os = require('os')
 const COMPONENT_GLOBAL = 'PlotlyExporterComponent'
 const PATH_TO_BUILD = path.join(os.tmpdir(), 'orca-build')
 try {
-  fs.mkdirSync(PATH_TO_BUILD)
+  fs.mkdirSync(PATH_TO_BUILD, 0o777)
 } catch (e) {}
 const PATH_TO_INIT_RENDERERS = path.join(__dirname, 'init-renderers.js')
 const PATH_TO_INIT_PINGS = path.join(__dirname, 'init-pings.js')


### PR DESCRIPTION
Per discussion in #140, this change ensures that when orca's build directory is created, it is world-writeable. This is necessary on multi-user systems so that if one user creates the build directory, other users can use it.