### PR TITLE
printToPDF: use Promise instead of callback

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -95,7 +95,7 @@ RUN cd /opt && \
 # Install latest stable Inkscape
 RUN apt-get update && apt-get install -y software-properties-common python-software-properties \
     && add-apt-repository -y ppa:inkscape.dev/stable \
-    && apt-get update && apt-get install -y inkscape=0.92.4+68~ubuntu16.04.1 \
+    && apt-get update && apt-get install -y inkscape=0.92.5+68~ubuntu16.04.1 \
     && rm -rf /var/lib/apt/lists/* && apt-get clean
 
 # Copy Inkscape defaults

--- a/src/component/plotly-graph/render.js
+++ b/src/component/plotly-graph/render.js
@@ -207,19 +207,15 @@ function toPDF (imgData, imgOpts, bgColor) {
       img.onerror = reject
       img.src = "${imgData}"
       setTimeout(() => reject(new Error('too long to load image')), ${cst.pdfPageLoadImgTimeout})
-    })`).then(() => {
-      win.webContents.printToPDF(printOpts, (err, pdfData) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(pdfData)
-        }
+    })`)
+      .then(() => win.webContents.printToPDF(printOpts))
+      .then(pdfData => {
         win.close()
+        resolve(pdfData)
+      }).catch((err) => {
+        win.close()
+        reject(err)
       })
-    }).catch((err) => {
-      reject(err)
-      win.close()
-    })
   })
 }
 

--- a/test/unit/plotly-graph_test.js
+++ b/test/unit/plotly-graph_test.js
@@ -744,7 +744,7 @@ tap.test('render:', t => {
       mockBrowser()
       const { win, restore } = mockWindow()
       win.webContents.executeJavaScript.returns(new Promise(resolve => resolve()))
-      win.webContents.printToPDF.yields(null, 'pdf data')
+      win.webContents.printToPDF.returns(Promise.resolve('pdf data'))
 
       fn({ format: 'pdf' }, {}, (errorCode, result) => {
         t.equal(errorCode, null)
@@ -835,7 +835,7 @@ tap.test('render:', t => {
       mockBrowser()
       const { win, restore } = mockWindow()
       win.webContents.executeJavaScript.returns(new Promise(resolve => resolve()))
-      win.webContents.printToPDF.yields(null, 'pdf data')
+      win.webContents.printToPDF.returns(Promise.resolve('pdf data'))
 
       fn({ format: 'pdf' }, {}, (errorCode, result) => {
         t.equal(errorCode, null)
@@ -903,7 +903,7 @@ tap.test('render:', t => {
     mockBrowser()
     const { win, restore } = mockWindow()
     win.webContents.executeJavaScript.returns(new Promise(resolve => resolve()))
-    win.webContents.printToPDF.yields(new Error('oops'))
+    win.webContents.printToPDF.returns(Promise.reject(new Error('oops')))
 
     fn({ format: 'pdf' }, {}, (errorCode, result) => {
       t.equal(errorCode, 525)


### PR DESCRIPTION
This PR uses the promise-based `printToPDF` because the callback-based function will soon be deprecated

Also, the Docker image wouldn't build because the Inkscape package we were using is not available anymore. This PR also fixes this problem.