### PR TITLE
dash-preview: fix for "Too many windows opened"

### DIFF
--- a/test/dash-preview/mocks/1.json
+++ b/test/dash-preview/mocks/1.json
@@ -1,8 +1,0 @@
-{
-  "url": "https://dash-demo.plotly.host/report-demo/report/report-1546830621-9989?print=true",
-  "timeout": "15",
-  "pdf_options": {
-    "pageSize": "Letter",
-    "marginsType": 1
-  }
-}

--- a/test/dash-preview/mocks/5.json
+++ b/test/dash-preview/mocks/5.json
@@ -1,9 +1,0 @@
-{
-  "url": "https://dash-nightly.plotly.host/ddk-manufacture-spc-dashboard/snapshot-1569944213-f1e08e4a?print=true",
-  "timeout": "15",
-  "pdf_options": {
-    "marginsType": 1,
-    "landscape": true
-  },
-  "pageSize": "A4"
-}

--- a/test/dash-preview/mocks/report_alternating_footers.json
+++ b/test/dash-preview/mocks/report_alternating_footers.json
@@ -1,8 +1,0 @@
-{
-  "url": "https://dash-design-table-css-s-fuheoq.herokuapp.com/report_alternating_footers?print=true",
-  "timeout": "10",
-  "pdf_options": {
-    "pageSize": "Letter",
-    "marginsType": 1
-  }
-}

--- a/test/dash-preview/mocks/report_alternating_margins.json
+++ b/test/dash-preview/mocks/report_alternating_margins.json
@@ -1,9 +1,0 @@
-{
-  "url": "https://dash-design-table-css-s-fuheoq.herokuapp.com/report_alternating_margins?print=true",
-  "timeout": "10",
-  "pdf_options": {
-    "pageSize": "Legal",
-    "landscape": true,
-    "marginsType": 1
-  }
-}

--- a/test/dash-preview/mocks/report_defaults.json
+++ b/test/dash-preview/mocks/report_defaults.json
@@ -1,8 +1,0 @@
-{
-  "url": "https://dash-design-table-css-s-fuheoq.herokuapp.com/report_defaults?print=true",
-  "timeout": "10",
-  "pdf_options": {
-    "pageSize": "Letter",
-    "marginsType": 1
-  }
-}

--- a/test/dash-preview/mocks/report_graph.json
+++ b/test/dash-preview/mocks/report_graph.json
@@ -1,8 +1,0 @@
-{
-  "url": "https://dash-design-table-css-s-fuheoq.herokuapp.com/report_graph?print=true",
-  "timeout": "10",
-  "pdf_options": {
-    "pageSize": "Letter",
-    "marginsType": 1
-  }
-}

--- a/test/dash-preview/mocks/report_graph_dimensions.json
+++ b/test/dash-preview/mocks/report_graph_dimensions.json
@@ -1,8 +1,0 @@
-{
-  "url": "https://dash-design-table-css-s-fuheoq.herokuapp.com/report_graph_dimensions?print=true",
-  "timeout": "10",
-  "pdf_options": {
-    "pageSize": "Letter",
-    "marginsType": 1
-  }
-}

--- a/test/dash-preview/mocks/report_page_numbers.json
+++ b/test/dash-preview/mocks/report_page_numbers.json
@@ -1,8 +1,0 @@
-{
-  "url": "https://dash-design-table-css-s-fuheoq.herokuapp.com/report_page_numbers?print=true",
-  "timeout": "10",
-  "pdf_options": {
-    "pageSize": "Letter",
-    "marginsType": 1
-  }
-}

--- a/test/dash-preview/mocks/report_page_numbers_margins.json
+++ b/test/dash-preview/mocks/report_page_numbers_margins.json
@@ -1,9 +1,0 @@
-{
-  "url": "https://dash-design-table-css-s-fuheoq.herokuapp.com/report_page_numbers_margins?print=true",
-  "timeout": "10",
-  "pdf_options": {
-    "pageSize": "A4",
-    "landscape": true,
-    "marginsType": 1
-  }
-}

--- a/test/dash-preview/mocks/report_table.json
+++ b/test/dash-preview/mocks/report_table.json
@@ -1,8 +1,0 @@
-{
-  "url": "https://dash-design-table-css-s-fuheoq.herokuapp.com/report_table?print=true",
-  "timeout": "10",
-  "pdf_options": {
-    "pageSize": "Letter",
-    "marginsType": 1
-  }
-}


### PR DESCRIPTION
It seems that sometimes `printToPDF` does not complete and hangs forever (see https://github.com/electron/electron/issues/20634). This is problematic because the window stays open forever. If you get this problem often, there will eventually be too many windows opened and you will get an out of memory error.

This PR introduces a change that will automatically close the window if a timeout was provided and if `printToPDF` takes longer than it. The rationale is that printing to PDF should not take longer than the initial page load so we can rely on the user's provided timeout. 

A more elegant approach would be to perform cleanup at the component level whenever the HTTP server drops a client request because it's taking too long. At the moment, we keep working even if the connection is dropped...

cc @alexcjohnson @josegonzalez 