### PR TITLE
update README.md with homebrew option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ your operating system from the
 
 #### Mac OS
 
+With [Homebrew](https://brew.sh/):
+
+- install the cask with `brew cask install orca`.
+- Open finder and navigate to the `Applications/` folder.
+- Right-click on the orca icon and select _Open_ from the context menu.
+- A password dialog will appear asking for permission to add orca to your system `PATH`.
+- Enter you password and click _OK_.
+- This should open an _Installation Succeeded_ window.
+- Open a new terminal and verify that the orca executable is available on your `PATH`.
+
+```
+$ which orca
+/usr/local/bin/orca
+
+$ orca --help
+Plotly's image-exporting utilities
+
+  Usage: orca [--version] [--help] <command> [<args>]
+  ...
+```
+
+Without Homebrew:
+
 - Unzip the `mac-release.zip` file.
 - Double-click on the `orca-X.Y.Z.dmg` file. This will open an installation window.
 - Drag the orca icon into the `Applications` folder.


### PR DESCRIPTION
For Mac OS, it's now possible to install orca using a brew cask.
See Homebrew/homebrew-cask#82160