### PR TITLE
MATHJax font options for Orca

### DIFF
--- a/src/component/plotly-graph/constants.js
+++ b/src/component/plotly-graph/constants.js
@@ -33,7 +33,8 @@ module.exports = {
   },
 
   mathJaxConfigQuery: '?config=TeX-AMS-MML_SVG',
-
+  mathJaxFontQuery: 'if (window.MathJax) {MathJax.Hub.Config({SVG: {blacker: 1, font: "STIX-Web"}});}',
+  
   // config option passed in render step
   plotGlPixelRatio: 2.5,
 

--- a/src/component/plotly-graph/inject.js
+++ b/src/component/plotly-graph/inject.js
@@ -23,6 +23,7 @@ function inject (opts = {}) {
     let src = resolve(mathjax)
     if (src) {
       parts.push(script(src + cst.mathJaxConfigQuery))
+      parts.push(scriptMathJaxFont(cst.mathJaxFontQuery))
     } else {
       throw new Error('Provided path to MathJax files does not exists')
     }
@@ -64,6 +65,10 @@ function resolve (v) {
 
 function script (src) {
   return `<script src="${src}"></script>`
+}
+
+function scriptMathJaxFont (opts) {
+  return `<script type="text/javascript">${opts}</script>`
 }
 
 function cdnSrc (v) {


### PR DESCRIPTION
I had to use plotly's graphs for publications and some of them contained TeX-based text. Plotly's graph font options and TeX font options were always mismatching and thicker in strokes, even while I knew MathJAX had the capabilities to publish in Modern Math or few others. 

MathJAX's SVG output processor provides certain [font options](https://docs.mathjax.org/en/v2.7-latest/options/output-processors/SVG.html). By not selecting explicitly earlier, Orca would output images in `STIX-Web` font with the default `blacker:1` attribute which renders a slight difference for TeX-rendered fonts compared to the overall Graph fonts.

Included are a couple lines of code for `constants.js` and `inject.js` to enable changing the fonts by changing a parameter in `constants.js` _manually_. Future feature requests may consider exposing this to the plotly export feature, if at all. 